### PR TITLE
[codex] Fix issue 63 SQL aggregation

### DIFF
--- a/src/lib/server/utils/db-helpers.ts
+++ b/src/lib/server/utils/db-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared database helper types and utilities for handling Drizzle raw query results.
+ *
+ * Drizzle's `db.execute()` returns `T[]` in production (postgres-js) but `{ rows: T[] }`
+ * in tests (PGlite). These helpers normalize both shapes.
+ */
+
+export type BucketCountRow = {
+  bucketIndex: number;
+  count: number;
+};
+
+export type QueryRows<T> = T[] | { rows: T[] };
+
+export function getQueryRows<T>(result: QueryRows<T>): T[] {
+  return Array.isArray(result) ? result : result.rows;
+}

--- a/src/routes/api/projects/[id]/incidents/[incidentId]/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/[incidentId]/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '$lib/server/db/schema';
@@ -9,6 +9,28 @@ import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/proj
 import type { RequestEvent } from './$types';
 
 type DatabaseClient = PostgresJsDatabase<typeof schema> | PgliteDatabase<typeof schema>;
+
+type SourceFrequencyRow = {
+  sourceFile: string | null;
+  lineNumber: number | null;
+  count: number;
+};
+
+type RequestFrequencyRow = {
+  requestId: string;
+  count: number;
+};
+
+type TraceFrequencyRow = {
+  traceId: string;
+  count: number;
+};
+
+type QueryRows<T> = T[] | { rows: T[] };
+
+function getQueryRows<T>(result: QueryRows<T>): T[] {
+  return Array.isArray(result) ? result : result.rows;
+}
 
 async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
   if (locals.db) return locals.db as DatabaseClient;
@@ -36,51 +58,55 @@ export async function GET(event: RequestEvent): Promise<Response> {
     return json({ error: 'not_found', message: 'Incident not found' }, { status: 404 });
   }
 
-  const incidentLogs = await db
-    .select({
-      sourceFile: log.sourceFile,
-      lineNumber: log.lineNumber,
-      requestId: log.requestId,
-      traceId: log.traceId,
-    })
-    .from(log)
-    .where(and(eq(log.projectId, projectId), eq(log.incidentId, incidentId)));
+  const logWhereClause = and(eq(log.projectId, projectId), eq(log.incidentId, incidentId));
 
-  const sourceFrequency = new Map<
-    string,
-    { sourceFile: string | null; lineNumber: number | null; count: number }
-  >();
-  const requestCounts = new Map<string, number>();
-  const traceCounts = new Map<string, number>();
+  const [sourceResult, requestResult, traceResult] = await Promise.all([
+    db.execute(sql<SourceFrequencyRow>`
+      select
+        ${log.sourceFile} as "sourceFile",
+        ${log.lineNumber} as "lineNumber",
+        count(*)::int as "count"
+      from ${log}
+      where ${logWhereClause}
+      group by ${log.sourceFile}, ${log.lineNumber}
+      order by "count" desc, ${log.sourceFile} asc nulls last, ${log.lineNumber} asc nulls last
+      limit 5
+    `),
+    db.execute(sql<RequestFrequencyRow>`
+      select
+        ${log.requestId} as "requestId",
+        count(*)::int as "count"
+      from ${log}
+      where ${logWhereClause} and ${log.requestId} is not null and ${log.requestId} <> ''
+      group by ${log.requestId}
+      order by "count" desc, ${log.requestId} asc
+      limit 10
+    `),
+    db.execute(sql<TraceFrequencyRow>`
+      select
+        ${log.traceId} as "traceId",
+        count(*)::int as "count"
+      from ${log}
+      where ${logWhereClause} and ${log.traceId} is not null and ${log.traceId} <> ''
+      group by ${log.traceId}
+      order by "count" desc, ${log.traceId} asc
+      limit 10
+    `),
+  ]);
 
-  for (const entry of incidentLogs) {
-    const sourceKey = `${entry.sourceFile ?? 'unknown'}:${entry.lineNumber ?? 0}`;
-    const current = sourceFrequency.get(sourceKey);
-    sourceFrequency.set(sourceKey, {
-      sourceFile: entry.sourceFile,
-      lineNumber: entry.lineNumber,
-      count: (current?.count ?? 0) + 1,
-    });
-
-    if (entry.requestId) {
-      requestCounts.set(entry.requestId, (requestCounts.get(entry.requestId) ?? 0) + 1);
-    }
-    if (entry.traceId) {
-      traceCounts.set(entry.traceId, (traceCounts.get(entry.traceId) ?? 0) + 1);
-    }
-  }
-
-  const rootCauseCandidates = [...sourceFrequency.values()]
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 5);
-  const topRequestIds = [...requestCounts.entries()]
-    .map(([requestId, count]) => ({ requestId, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 10);
-  const topTraceIds = [...traceCounts.entries()]
-    .map(([traceId, count]) => ({ traceId, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 10);
+  const rootCauseCandidates = getQueryRows(sourceResult).map((row) => ({
+    sourceFile: row.sourceFile,
+    lineNumber: row.lineNumber,
+    count: Number(row.count),
+  }));
+  const topRequestIds = getQueryRows(requestResult).map((row) => ({
+    requestId: row.requestId,
+    count: Number(row.count),
+  }));
+  const topTraceIds = getQueryRows(traceResult).map((row) => ({
+    traceId: row.traceId,
+    count: Number(row.count),
+  }));
 
   return json({
     id: incidentRow.id,

--- a/src/routes/api/projects/[id]/incidents/[incidentId]/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/[incidentId]/+server.ts
@@ -4,6 +4,7 @@ import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '$lib/server/db/schema';
 import { incident, log } from '$lib/server/db/schema';
+import { getQueryRows } from '$lib/server/utils/db-helpers';
 import { getIncidentStatus } from '$lib/server/utils/incidents';
 import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/project-guard';
 import type { RequestEvent } from './$types';
@@ -25,12 +26,6 @@ type TraceFrequencyRow = {
   traceId: string;
   count: number;
 };
-
-type QueryRows<T> = T[] | { rows: T[] };
-
-function getQueryRows<T>(result: QueryRows<T>): T[] {
-  return Array.isArray(result) ? result : result.rows;
-}
 
 async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
   if (locals.db) return locals.db as DatabaseClient;

--- a/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { and, eq, gte, lte, type SQL } from 'drizzle-orm';
+import { and, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '$lib/server/db/schema';
@@ -7,10 +7,21 @@ import { incident, log } from '$lib/server/db/schema';
 import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/project-guard';
 import { INCIDENT_RANGES, type IncidentRange } from '$lib/shared/types';
 import { getTimeRangeStart } from '$lib/utils/format';
-import { bucketTimestamps, fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
+import { fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
 import type { RequestEvent } from './$types';
 
 type DatabaseClient = PostgresJsDatabase<typeof schema> | PgliteDatabase<typeof schema>;
+
+type BucketCountRow = {
+  bucketIndex: number;
+  count: number;
+};
+
+type QueryRows<T> = T[] | { rows: T[] };
+
+function getQueryRows<T>(result: QueryRows<T>): T[] {
+  return Array.isArray(result) ? result : result.rows;
+}
 
 async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
   if (locals.db) return locals.db as DatabaseClient;
@@ -58,11 +69,32 @@ export async function GET(event: RequestEvent): Promise<Response> {
     lte(log.timestamp, rangeEnd),
   ];
   const whereClause = and(...conditions);
+  const intervalSeconds = config.intervalMs / 1000;
 
-  const logs = await db.select({ timestamp: log.timestamp }).from(log).where(whereClause);
-  const timestamps = logs.map((l) => l.timestamp).filter((ts): ts is Date => ts !== null);
+  const bucketResult = await db.execute(sql<BucketCountRow>`
+    select
+      floor(
+        (
+          extract(epoch from ${log.timestamp}) -
+          extract(epoch from ${rangeStart}::timestamptz)
+        ) / ${intervalSeconds}
+      )::int as "bucketIndex",
+      count(*)::int as "count"
+    from ${log}
+    where ${whereClause}
+    group by 1
+    order by 1
+  `);
 
-  const bucketCounts = bucketTimestamps(timestamps, config, rangeStart);
+  const bucketCounts: Record<number, number> = {};
+  for (const row of getQueryRows(bucketResult)) {
+    const bucketIndex = Number(row.bucketIndex);
+    const count = Number(row.count);
+    if (bucketIndex >= 0 && bucketIndex < config.expectedBuckets) {
+      bucketCounts[bucketIndex] = count;
+    }
+  }
+
   const buckets = fillMissingBuckets(bucketCounts, config, rangeStart, rangeEnd);
   const peakBucket = buckets.reduce<{ timestamp: string; count: number } | null>((peak, bucket) => {
     if (!peak) return bucket;

--- a/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
@@ -70,14 +70,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
   ];
   const whereClause = and(...conditions);
   const intervalSeconds = config.intervalMs / 1000;
+  const rangeStartEpochSeconds = rangeStart.getTime() / 1000;
 
   const bucketResult = await db.execute(sql<BucketCountRow>`
     select
       floor(
-        (
-          extract(epoch from ${log.timestamp}) -
-          extract(epoch from ${rangeStart}::timestamptz)
-        ) / ${intervalSeconds}
+        (extract(epoch from ${log.timestamp}) - ${rangeStartEpochSeconds}) / ${intervalSeconds}
       )::int as "bucketIndex",
       count(*)::int as "count"
     from ${log}

--- a/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server.ts
@@ -4,6 +4,7 @@ import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '$lib/server/db/schema';
 import { incident, log } from '$lib/server/db/schema';
+import { type BucketCountRow, getQueryRows } from '$lib/server/utils/db-helpers';
 import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/project-guard';
 import { INCIDENT_RANGES, type IncidentRange } from '$lib/shared/types';
 import { getTimeRangeStart } from '$lib/utils/format';
@@ -11,23 +12,6 @@ import { fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
 import type { RequestEvent } from './$types';
 
 type DatabaseClient = PostgresJsDatabase<typeof schema> | PgliteDatabase<typeof schema>;
-
-type BucketCountRow = {
-  bucketIndex: number;
-  count: number;
-};
-
-type QueryRows<T> = T[] | { rows: T[] };
-
-function getQueryRows<T>(result: QueryRows<T>): T[] {
-  return Array.isArray(result) ? result : result.rows;
-}
-
-async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
-  if (locals.db) return locals.db as DatabaseClient;
-  const { db } = await import('$lib/server/db');
-  return db;
-}
 
 /**
  * GET /api/projects/[id]/incidents/[incidentId]/timeline
@@ -109,4 +93,10 @@ export async function GET(event: RequestEvent): Promise<Response> {
       lastSeen: incidentRow.lastSeen.toISOString(),
     },
   });
+}
+
+async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
+  if (locals.db) return locals.db as DatabaseClient;
+  const { db } = await import('$lib/server/db');
+  return db;
 }

--- a/src/routes/api/projects/[id]/stats/timeseries/+server.ts
+++ b/src/routes/api/projects/[id]/stats/timeseries/+server.ts
@@ -5,6 +5,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { TimeRange } from '$lib/components/time-range-picker.svelte';
 import type * as schema from '$lib/server/db/schema';
 import { log } from '$lib/server/db/schema';
+import { type BucketCountRow, getQueryRows } from '$lib/server/utils/db-helpers';
 import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/project-guard';
 import { getTimeRangeStart } from '$lib/utils/format';
 import { fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
@@ -25,17 +26,6 @@ async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
 }
 
 const VALID_RANGES: TimeRange[] = ['15m', '1h', '24h', '7d'];
-
-type BucketCountRow = {
-  bucketIndex: number;
-  count: number;
-};
-
-type QueryRows<T> = T[] | { rows: T[] };
-
-function getQueryRows<T>(result: QueryRows<T>): T[] {
-  return Array.isArray(result) ? result : result.rows;
-}
 
 /**
  * GET /api/projects/[id]/stats/timeseries

--- a/src/routes/api/projects/[id]/stats/timeseries/+server.ts
+++ b/src/routes/api/projects/[id]/stats/timeseries/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { and, eq, gte, lte, type SQL } from 'drizzle-orm';
+import { and, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { TimeRange } from '$lib/components/time-range-picker.svelte';
@@ -7,7 +7,7 @@ import type * as schema from '$lib/server/db/schema';
 import { log } from '$lib/server/db/schema';
 import { isErrorResponse, requireProjectOwnership } from '$lib/server/utils/project-guard';
 import { getTimeRangeStart } from '$lib/utils/format';
-import { bucketTimestamps, fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
+import { fillMissingBuckets, getTimeBucketConfig } from '$lib/utils/timeseries';
 import type { RequestEvent } from './$types';
 
 type DatabaseClient = PostgresJsDatabase<typeof schema> | PgliteDatabase<typeof schema>;
@@ -25,6 +25,17 @@ async function getDbClient(locals: App.Locals): Promise<DatabaseClient> {
 }
 
 const VALID_RANGES: TimeRange[] = ['15m', '1h', '24h', '7d'];
+
+type BucketCountRow = {
+  bucketIndex: number;
+  count: number;
+};
+
+type QueryRows<T> = T[] | { rows: T[] };
+
+function getQueryRows<T>(result: QueryRows<T>): T[] {
+  return Array.isArray(result) ? result : result.rows;
+}
 
 /**
  * GET /api/projects/[id]/stats/timeseries
@@ -82,19 +93,35 @@ export async function GET(event: RequestEvent): Promise<Response> {
   ];
 
   const whereClause = and(...conditions);
+  const intervalSeconds = config.intervalMs / 1000;
 
-  // Fetch log timestamps in range
-  const logs = await db.select({ timestamp: log.timestamp }).from(log).where(whereClause);
+  const bucketResult = await db.execute(sql<BucketCountRow>`
+    select
+      floor(
+        (
+          extract(epoch from ${log.timestamp}) -
+          extract(epoch from ${rangeStart}::timestamptz)
+        ) / ${intervalSeconds}
+      )::int as "bucketIndex",
+      count(*)::int as "count"
+    from ${log}
+    where ${whereClause}
+    group by 1
+    order by 1
+  `);
 
-  // Convert to Date objects (filter nulls)
-  const timestamps = logs.map((l) => l.timestamp).filter((ts): ts is Date => ts !== null);
+  const bucketCounts: Record<number, number> = {};
+  let totalCount = 0;
+  for (const row of getQueryRows(bucketResult)) {
+    const bucketIndex = Number(row.bucketIndex);
+    const count = Number(row.count);
+    if (bucketIndex >= 0 && bucketIndex < config.expectedBuckets) {
+      bucketCounts[bucketIndex] = count;
+      totalCount += count;
+    }
+  }
 
-  // Bucket the timestamps
-  const bucketCounts = bucketTimestamps(timestamps, config, rangeStart);
   const buckets = fillMissingBuckets(bucketCounts, config, rangeStart, rangeEnd);
-
-  // Calculate total
-  const totalCount = timestamps.length;
 
   return json({
     buckets,

--- a/src/routes/api/projects/[id]/stats/timeseries/+server.ts
+++ b/src/routes/api/projects/[id]/stats/timeseries/+server.ts
@@ -94,14 +94,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
 
   const whereClause = and(...conditions);
   const intervalSeconds = config.intervalMs / 1000;
+  const rangeStartEpochSeconds = rangeStart.getTime() / 1000;
 
   const bucketResult = await db.execute(sql<BucketCountRow>`
     select
       floor(
-        (
-          extract(epoch from ${log.timestamp}) -
-          extract(epoch from ${rangeStart}::timestamptz)
-        ) / ${intervalSeconds}
+        (extract(epoch from ${log.timestamp}) - ${rangeStartEpochSeconds}) / ${intervalSeconds}
       )::int as "bucketIndex",
       count(*)::int as "count"
     from ${log}

--- a/tests/integration/api/projects/[id]/stats/timeseries.integration.test.ts
+++ b/tests/integration/api/projects/[id]/stats/timeseries.integration.test.ts
@@ -1,6 +1,6 @@
 import type { HttpError } from '@sveltejs/kit';
 import type { PgliteDatabase } from 'drizzle-orm/pglite';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAuth } from '$lib/server/auth';
 import type * as schema from '$lib/server/db/schema';
 import { setupTestDatabase } from '$lib/server/db/test-db';
@@ -233,6 +233,41 @@ describe('GET /api/projects/[id]/stats/timeseries', () => {
   });
 
   describe('Log Counting', () => {
+    it('does not select every matching log timestamp into memory', async () => {
+      const testProject = await seedProject(db, { ownerId: userId });
+      const now = new Date();
+      await seedLogs(db, testProject.id, 25, {
+        timestamp: new Date(now.getTime() - 30 * 60 * 1000),
+      });
+
+      const originalSelect = db.select.bind(db);
+      const selectSpy = vi.spyOn(db, 'select').mockImplementation(((fields?: unknown) => {
+        if (
+          fields &&
+          typeof fields === 'object' &&
+          Object.keys(fields).length === 1 &&
+          'timestamp' in fields
+        ) {
+          throw new Error('timeseries must aggregate timestamps in SQL');
+        }
+
+        return originalSelect(fields as never);
+      }) as typeof db.select);
+
+      const request = new Request(
+        `http://localhost/api/projects/${testProject.id}/stats/timeseries?range=1h`,
+        { method: 'GET' },
+      );
+
+      const event = createRequestEvent(request, db, { id: testProject.id }, authenticatedLocals);
+      const response = await GET(event as never);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.totalCount).toBe(25);
+      expect(selectSpy).not.toHaveBeenCalledWith({ timestamp: expect.anything() });
+    });
+
     it('returns correct count per bucket', async () => {
       const testProject = await seedProject(db, { ownerId: userId });
       const now = new Date();

--- a/tests/integration/api/projects/incidents/incidents.integration.test.ts
+++ b/tests/integration/api/projects/incidents/incidents.integration.test.ts
@@ -1,6 +1,6 @@
 import type { HttpError } from '@sveltejs/kit';
 import type { PgliteDatabase } from 'drizzle-orm/pglite';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAuth } from '$lib/server/auth';
 import type * as schema from '$lib/server/db/schema';
 import { incident } from '$lib/server/db/schema';
@@ -9,7 +9,7 @@ import { getSession } from '$lib/server/session';
 import { GET as GET_LIST } from '../../../../../src/routes/api/projects/[id]/incidents/+server';
 import { GET as GET_DETAIL } from '../../../../../src/routes/api/projects/[id]/incidents/[incidentId]/+server';
 import { GET as GET_TIMELINE } from '../../../../../src/routes/api/projects/[id]/incidents/[incidentId]/timeline/+server';
-import { seedLog, seedProject } from '../../../../fixtures/db';
+import { seedLog, seedLogs, seedProject } from '../../../../fixtures/db';
 
 function createRequestEvent(
   request: Request,
@@ -265,6 +265,73 @@ describe('Incident APIs', () => {
     });
   });
 
+  it('aggregates incident detail counts in SQL instead of selecting every incident log', async () => {
+    const project = await seedProject(db, { ownerId: userId });
+    const [createdIncident] = await db
+      .insert(incident)
+      .values({
+        id: 'inc-sql-detail',
+        projectId: project.id,
+        fingerprint: 'fp-sql-detail',
+        title: 'SQL detail',
+        normalizedMessage: 'sql detail',
+        serviceName: 'api',
+        sourceFile: 'src/detail.ts',
+        lineNumber: 1,
+        highestLevel: 'error',
+        firstSeen: new Date(Date.now() - 20 * 60 * 1000),
+        lastSeen: new Date(Date.now() - 5 * 60 * 1000),
+        totalEvents: 20,
+      })
+      .returning();
+
+    await seedLogs(db, project.id, 20, {
+      incidentId: createdIncident.id,
+      fingerprint: createdIncident.fingerprint,
+      level: 'error',
+      message: 'SQL detail',
+      sourceFile: 'src/detail.ts',
+      lineNumber: 1,
+      requestId: 'req-sql',
+      traceId: 'trace-sql',
+    });
+
+    const originalSelect = db.select.bind(db);
+    vi.spyOn(db, 'select').mockImplementation(((fields?: unknown) => {
+      if (
+        fields &&
+        typeof fields === 'object' &&
+        ['sourceFile', 'lineNumber', 'requestId', 'traceId'].every((key) => key in fields)
+      ) {
+        throw new Error('incident detail must aggregate log counts in SQL');
+      }
+
+      return originalSelect(fields as never);
+    }) as typeof db.select);
+
+    const request = new Request(
+      `http://localhost/api/projects/${project.id}/incidents/${createdIncident.id}`,
+    );
+    const event = createRequestEvent(
+      request,
+      db,
+      { id: project.id, incidentId: createdIncident.id },
+      authenticatedLocals,
+      '/api/projects/[id]/incidents/[incidentId]',
+    );
+    const response = await GET_DETAIL(event as never);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.rootCauseCandidates[0]).toEqual({
+      sourceFile: 'src/detail.ts',
+      lineNumber: 1,
+      count: 20,
+    });
+    expect(body.correlations.topRequestIds[0]).toEqual({ requestId: 'req-sql', count: 20 });
+    expect(body.correlations.topTraceIds[0]).toEqual({ traceId: 'trace-sql', count: 20 });
+  });
+
   it('returns timeline buckets with peak data', async () => {
     const project = await seedProject(db, { ownerId: userId });
     const [createdIncident] = await db
@@ -321,6 +388,65 @@ describe('Incident APIs', () => {
     expect(body.range).toBe('1h');
     expect(body.buckets.length).toBeGreaterThan(0);
     expect(body.peakBucket).not.toBeNull();
+  });
+
+  it('aggregates incident timeline buckets in SQL instead of selecting every timestamp', async () => {
+    const project = await seedProject(db, { ownerId: userId });
+    const [createdIncident] = await db
+      .insert(incident)
+      .values({
+        id: 'inc-sql-timeline',
+        projectId: project.id,
+        fingerprint: 'fp-sql-timeline',
+        title: 'SQL timeline',
+        normalizedMessage: 'sql timeline',
+        serviceName: 'api',
+        sourceFile: 'src/timeline.ts',
+        lineNumber: 1,
+        highestLevel: 'error',
+        firstSeen: new Date(Date.now() - 50 * 60 * 1000),
+        lastSeen: new Date(Date.now() - 5 * 60 * 1000),
+        totalEvents: 30,
+      })
+      .returning();
+
+    await seedLogs(db, project.id, 30, {
+      incidentId: createdIncident.id,
+      fingerprint: createdIncident.fingerprint,
+      level: 'error',
+      message: 'SQL timeline',
+      timestamp: new Date(Date.now() - 20 * 60 * 1000),
+    });
+
+    const originalSelect = db.select.bind(db);
+    vi.spyOn(db, 'select').mockImplementation(((fields?: unknown) => {
+      if (
+        fields &&
+        typeof fields === 'object' &&
+        Object.keys(fields).length === 1 &&
+        'timestamp' in fields
+      ) {
+        throw new Error('incident timeline must aggregate timestamps in SQL');
+      }
+
+      return originalSelect(fields as never);
+    }) as typeof db.select);
+
+    const request = new Request(
+      `http://localhost/api/projects/${project.id}/incidents/${createdIncident.id}/timeline?range=1h`,
+    );
+    const event = createRequestEvent(
+      request,
+      db,
+      { id: project.id, incidentId: createdIncident.id },
+      authenticatedLocals,
+      '/api/projects/[id]/incidents/[incidentId]/timeline',
+    );
+    const response = await GET_TIMELINE(event as never);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.peakBucket?.count).toBe(30);
   });
 
   it("returns 404 when user accesses another user's incident", async () => {


### PR DESCRIPTION
## Summary

Fixes issue 63 by moving stats/timeseries and incident aggregation work into SQL instead of loading all matching log rows into JavaScript memory.

## What changed

- Replaced stats timeseries timestamp fetching with SQL bucket aggregation and grouped counts.
- Replaced incident timeline timestamp fetching with the same SQL bucket aggregation pattern.
- Replaced incident detail in-memory source/request/trace counting with SQL `GROUP BY`, `COUNT(*)`, and `LIMIT` queries.
- Added TDD regression coverage that fails if these endpoints return to unaggregated log timestamp/detail selects.

## Validation

- `bun run test:integration -- 'tests/integration/api/projects/[id]/stats/timeseries.integration.test.ts'`
- `bun run test:integration -- tests/integration/api/projects/incidents/incidents.integration.test.ts`
- `bun run lint && bun run check && bun run knip`
- `bun run test` (76 files, 1021 tests passed)

Note: `bun run lint` still reports two pre-existing warning-only non-null assertions in `tests/integration/otlp/logs.integration.test.ts`; it exits 0.

Closes #63