### PR TITLE
docs: correct stale limitations and document rate-limit env vars (F2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,17 @@ ADMIN_PASSWORD="your-admin-password-here"
 # Default: 30, Range: 1-10080 (1 minute to 7 days)
 # INCIDENT_AUTO_RESOLVE_MINUTES="30"
 
+# Rate Limiting
+# -------------
+
+# Max ingest requests per minute, per project API key (token bucket)
+# Default: 600
+# RATE_LIMIT_INGEST_RPM="600"
+
+# Max login attempts per minute, per client IP (brute-force protection)
+# Default: 10
+# RATE_LIMIT_LOGIN_RPM="10"
+
 # =============================================================================
 # QUICK START
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ ORIGIN="https://your-domain.com"
 # LOG_RETENTION_DAYS="30"        # 0 = never auto-delete
 # LOG_CLEANUP_INTERVAL_MS="3600000"  # Cleanup job interval (1 hour)
 # INCIDENT_AUTO_RESOLVE_MINUTES="30" # Incident resolves after N quiet minutes
+
+# Rate limiting (optional, defaults shown)
+# RATE_LIMIT_INGEST_RPM="600"    # Max ingest requests per minute per API key
+# RATE_LIMIT_LOGIN_RPM="10"      # Max login attempts per minute per IP
 ```
 
 Generate a secure secret:
@@ -671,29 +675,30 @@ The app runs on port 3000 by default.
 
 ### Project Management (Session Auth)
 
-| Endpoint                                             | Method | Description                                   |
-| ---------------------------------------------------- | ------ | --------------------------------------------- |
-| `/api/projects`                                      | GET    | List all projects                             |
-| `/api/projects`                                      | POST   | Create project                                |
-| `/api/projects/[id]`                                 | GET    | Get project details                           |
-| `/api/projects/[id]`                                 | PATCH  | Update project (name, retention)              |
-| `/api/projects/[id]`                                 | DELETE | Delete project                                |
-| `/api/projects/[id]/regenerate`                      | POST   | Regenerate API key                            |
-| `/api/projects/[id]/logs`                            | GET    | Query logs                                    |
-| `/api/projects/[id]/logs/stream`                     | POST   | SSE stream                                    |
-| `/api/projects/[id]/incidents`                       | GET    | List incidents (open/resolved, range filters) |
-| `/api/projects/[id]/incidents/[incidentId]`          | GET    | Incident detail with root-cause candidates    |
-| `/api/projects/[id]/incidents/[incidentId]/timeline` | GET    | Incident timeline buckets + peak              |
-| `/api/projects/[id]/incidents/stream`                | POST   | SSE incident updates                          |
-| `/api/projects/[id]/stats`                           | GET    | Level distribution                            |
+| Endpoint                                             | Method | Description                                                  |
+| ---------------------------------------------------- | ------ | ------------------------------------------------------------ |
+| `/api/projects`                                      | GET    | List all projects                                            |
+| `/api/projects`                                      | POST   | Create project                                               |
+| `/api/projects/[id]`                                 | GET    | Get project details                                          |
+| `/api/projects/[id]`                                 | PATCH  | Update project (name, retention)                             |
+| `/api/projects/[id]`                                 | DELETE | Delete project                                               |
+| `/api/projects/[id]/regenerate`                      | POST   | Regenerate API key                                           |
+| `/api/projects/[id]/logs`                            | GET    | Query logs                                                   |
+| `/api/projects/[id]/logs/stream`                     | POST   | SSE stream                                                   |
+| `/api/projects/[id]/incidents`                       | GET    | List incidents (open/resolved, range filters)                |
+| `/api/projects/[id]/incidents/[incidentId]`          | GET    | Incident detail with root-cause candidates                   |
+| `/api/projects/[id]/incidents/[incidentId]/timeline` | GET    | Incident timeline buckets + peak                             |
+| `/api/projects/[id]/incidents/stream`                | POST   | SSE incident updates                                         |
+| `/api/projects/[id]/stats`                           | GET    | Level distribution                                           |
+| `/api/projects/[id]/logs/export`                     | GET    | Export logs as CSV or JSON (`?format=csv\|json`, max 10,000) |
 
 ## Current Limitations
 
-| Limitation           | Impact                         | Workaround                          |
-| -------------------- | ------------------------------ | ----------------------------------- |
-| **Single-user auth** | No team collaboration          | Share credentials (not recommended) |
-| **No log export**    | Can't backup to S3/file        | Direct database dumps via `pg_dump` |
-| **No rate limiting** | API keys have unlimited access | Implement at reverse proxy level    |
+| Limitation                      | Impact                                                                       | Workaround                                          |
+| ------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Single-user auth**            | No team collaboration                                                        | Share credentials (not recommended)                 |
+| **No alerting / notifications** | Incidents are detected but not pushed (no webhook/email)                     | Poll the incidents API or SSE stream                |
+| **No programmatic read API**    | Logs are readable via the UI or session-auth endpoints only, not via API key | Use session-auth `/api/projects/[id]/logs` endpoint |
 
 ## Security
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -24,7 +24,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | #   | Plan                                                                                                          | Finding | Category         | Priority | Effort | Risk    | Status |
 | --- | ------------------------------------------------------------------------------------------------------------- | ------- | ---------------- | -------- | ------ | ------- | ------ |
 | 001 | [Fix husky pre-commit hook](001-fix-husky-precommit-hook.md)                                                  | F4      | dx               | P2       | S      | LOW     | done   |
-| 002 | [Fix README limitations + document rate-limit env](002-fix-readme-limitations-and-document-rate-limit-env.md) | F2      | docs             | P2       | S      | LOW     | todo   |
+| 002 | [Fix README limitations + document rate-limit env](002-fix-readme-limitations-and-document-rate-limit-env.md) | F2      | docs             | P2       | S      | LOW     | done   |
 | 003 | [Pin vite-plus + toolchain versions](003-pin-vite-plus-toolchain-versions.md)                                 | F14     | migration (deps) | P2       | S      | LOW     | todo   |
 | 004 | [Raise SDK runtime floors](004-raise-sdk-runtime-floors.md)                                                   | F15     | migration (deps) | P3       | S      | LOW     | todo   |
 | 005 | [Fix knip config + remove dead searchLogs](005-fix-knip-config-and-remove-dead-searchlogs.md)                 | F10+F5  | tech-debt        | P2       | S      | LOW-MED | todo   |


### PR DESCRIPTION
## Plan 002 — Correct README "Current Limitations" + document rate-limit env vars (finding F2)

The README's "Current Limitations" table falsely claimed **"No log export"** and **"No rate limiting"** — both ship today (`src/routes/api/projects/[id]/logs/export/+server.ts`; `src/lib/server/utils/rate-limit.ts`). The two rate-limit env vars were also undocumented.

### Changes (docs-only)
- **README.md**: removed the two false limitation rows (kept the accurate **Single-user auth** row); replaced with two *verified* real limitations (no alerting/notifications; no programmatic read API). Added the export endpoint to the API Reference table. Added `RATE_LIMIT_*` to the Environment Variables section.
- **.env.example**: new "Rate Limiting" subsection under PERFORMANCE TUNING documenting `RATE_LIMIT_INGEST_RPM` (default 600) and `RATE_LIMIT_LOGIN_RPM` (default 10) — defaults match `rate-limit.ts:18-19`.
- **plans/README.md**: plan 002 status → `done`.

### Verification
- `vp check` → exit 0 (markdown prettier clean)
- All done-criteria greps confirmed (no "No log export"/"No rate limiting"; export + both RATE_LIMIT vars documented)
- No `src/` files touched.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
