### PR TITLE
fix(security): require real BETTER_AUTH_SECRET outside explicit development (F6)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -30,7 +30,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 005 | [Fix knip config + remove dead searchLogs](005-fix-knip-config-and-remove-dead-searchlogs.md)                 | F10+F5  | tech-debt        | P2       | S      | LOW-MED | done   |
 | 006 | [Fix SSE backpressure dropping live events](006-fix-sse-backpressure-dropping-live-events.md)                 | F1      | bug              | P1       | S      | LOW     | todo   |
 | 007 | [Fix OTLP zero-timestamp handling](007-fix-otlp-zero-timestamp.md)                                            | F17     | bug              | P2       | S      | LOW     | todo   |
-| 008 | [Harden fallback auth secret](008-harden-fallback-auth-secret.md)                                             | F6      | security         | P2       | S      | LOW     | todo   |
+| 008 | [Harden fallback auth secret](008-harden-fallback-auth-secret.md)                                             | F6      | security         | P2       | S      | LOW     | done   |
 | 009 | [Tighten CSRF for cookie routes](009-tighten-csrf-for-cookie-routes.md)                                       | F16     | security         | P3       | S      | LOW     | todo   |
 | 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | todo   |
 | 011 | [Test incidents SSE stream](011-test-incidents-sse-stream.md)                                                 | F9      | tests            | P2       | M      | LOW     | todo   |

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -30,7 +30,7 @@ export class EnvValidationError extends Error {
 
 // Get NODE_ENV first for conditional validation
 const nodeEnv = process.env.NODE_ENV || "development";
-const isProd = nodeEnv === "production";
+const isDevExplicit = nodeEnv === "development";
 
 // Collect validation errors
 const validationErrors: Array<{ variable: string; message: string }> = [];
@@ -59,11 +59,11 @@ function getDatabaseUrl(): string {
 
 // Validate BETTER_AUTH_SECRET
 const authSecret = process.env.BETTER_AUTH_SECRET;
-if (isProd) {
+if (!isDevExplicit) {
   if (!authSecret) {
     validationErrors.push({
       variable: "BETTER_AUTH_SECRET",
-      message: "BETTER_AUTH_SECRET environment variable is required in production",
+      message: "BETTER_AUTH_SECRET is required unless NODE_ENV=development",
     });
   } else if (authSecret.length < 32) {
     validationErrors.push({
@@ -90,8 +90,8 @@ export const env = {
   /** PostgreSQL connection string */
   DATABASE_URL: getDatabaseUrl(),
 
-  /** Secret key for better-auth sessions (defaults to dev secret in development) */
-  BETTER_AUTH_SECRET: authSecret || "default-secret-for-development-only",
+  /** Secret key for better-auth sessions (defaults to dev secret in explicit development) */
+  BETTER_AUTH_SECRET: authSecret ?? (isDevExplicit ? "default-secret-for-development-only" : ""),
 
   /** Password for seeding admin user (optional) */
   ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
@@ -155,11 +155,14 @@ export function validateEnv(): ValidationResult {
     });
   }
 
-  if (isProduction()) {
+  const currentNodeEnv = process.env.NODE_ENV || "development";
+  const currentIsDevExplicit = currentNodeEnv === "development";
+
+  if (!currentIsDevExplicit) {
     if (!process.env.BETTER_AUTH_SECRET) {
       errors.push({
         variable: "BETTER_AUTH_SECRET",
-        message: "BETTER_AUTH_SECRET is required in production",
+        message: "BETTER_AUTH_SECRET is required unless NODE_ENV=development",
       });
     } else if (process.env.BETTER_AUTH_SECRET.length < 32) {
       errors.push({

--- a/src/lib/server/config/env.unit.test.ts
+++ b/src/lib/server/config/env.unit.test.ts
@@ -194,14 +194,82 @@ describe("Environment Configuration", () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it("returns all validation errors at once", async () => {
-      delete process.env.DATABASE_URL;
-      process.env.NODE_ENV = "production";
+    it("returns invalid when NODE_ENV=production and secret is missing", async () => {
+      // Load module under development so it does not throw at import
+      process.env.DATABASE_URL = "postgres://localhost/test";
+      process.env.NODE_ENV = "development";
       delete process.env.BETTER_AUTH_SECRET;
 
-      // Can't test this via import since it throws, use internal validation
-      // This test validates that the validateEnv function returns all errors
-      // The actual implementation should collect all errors before throwing
+      const { validateEnv } = await import("./env");
+
+      // Now simulate production environment for the validateEnv call
+      process.env.NODE_ENV = "production";
+      const result = validateEnv();
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.variable === "BETTER_AUTH_SECRET")).toBe(true);
+    });
+
+    it("returns invalid when NODE_ENV=staging (non-dev, non-prod) and secret is missing", async () => {
+      // Load module under development so it does not throw at import
+      process.env.DATABASE_URL = "postgres://localhost/test";
+      process.env.NODE_ENV = "development";
+      delete process.env.BETTER_AUTH_SECRET;
+
+      const { validateEnv } = await import("./env");
+
+      // Now simulate staging environment for the validateEnv call
+      process.env.NODE_ENV = "staging";
+      const result = validateEnv();
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.variable === "BETTER_AUTH_SECRET")).toBe(true);
+    });
+
+    it("returns valid when NODE_ENV=development and secret is missing", async () => {
+      process.env.DATABASE_URL = "postgres://localhost/test";
+      process.env.NODE_ENV = "development";
+      delete process.env.BETTER_AUTH_SECRET;
+
+      const { validateEnv } = await import("./env");
+      const result = validateEnv();
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("returns invalid when NODE_ENV=production and secret is too short", async () => {
+      // Load module under development so it does not throw at import
+      process.env.DATABASE_URL = "postgres://localhost/test";
+      process.env.NODE_ENV = "development";
+      delete process.env.BETTER_AUTH_SECRET;
+
+      const { validateEnv } = await import("./env");
+
+      // Now simulate production with short secret
+      process.env.NODE_ENV = "production";
+      process.env.BETTER_AUTH_SECRET = "too-short";
+      const result = validateEnv();
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.variable === "BETTER_AUTH_SECRET")).toBe(true);
+    });
+
+    it("returns valid when NODE_ENV=production and secret is 32+ chars", async () => {
+      // Load module under development so it does not throw at import
+      process.env.DATABASE_URL = "postgres://localhost/test";
+      process.env.NODE_ENV = "development";
+      delete process.env.BETTER_AUTH_SECRET;
+
+      const { validateEnv } = await import("./env");
+
+      // Now simulate production with valid secret
+      process.env.NODE_ENV = "production";
+      process.env.BETTER_AUTH_SECRET = "a".repeat(32);
+      const result = validateEnv();
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Plan 008 — Require a real BETTER_AUTH_SECRET outside explicit development (finding F6)

`BETTER_AUTH_SECRET` fell back to a hardcoded constant (`"default-secret-for-development-only"`), and the requirement/length check only ran when `NODE_ENV === "production"`. A self-hoster who starts the prod server without `NODE_ENV=production` (running built output directly, a PaaS that sets `NODE_ENV=staging`, `bun run preview`, etc.) would silently sign session cookies with a **publicly-known constant** — anyone could forge a valid session. This fails fast instead.

### Changes
- **src/lib/server/config/env.ts**: the dev fallback constant is now used **only** when `NODE_ENV === "development"` (explicit). Any other value (staging/test/production/unrecognized) requires a real 32+ char secret and fails validation at module load. `validateEnv()` mirrors the logic, re-reading `process.env.NODE_ENV` at call time so diagnostics match runtime. (`isProd` was removed — it was only used in the replaced block.)
- **src/lib/server/config/env.unit.test.ts**: 5 new cases (production/staging/dev × missing/short/valid secret).
- **plans/README.md**: plan 008 status → `done`.

### Why it's safe
`NODE_ENV` still defaults to `"development"` when unset, so zero-config local dev is unchanged. The empty-string default branch is unreachable at runtime (validation throws first); it only satisfies the `as const` type. `auth.ts` is untouched.

### Verification
- `bun run test:unit -- env` (26), full `test:unit` (334), `test:integration`, `bun run check`, `vp check`, `knip`, build → all green
- Regression proof: reverting `validateEnv()` to the old `isProduction()` logic makes 3 new tests fail.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
