### PR TITLE
fix(sse): stop dropping live events on bursts above the batch size (F1)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -28,7 +28,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 003 | [Pin vite-plus + toolchain versions](003-pin-vite-plus-toolchain-versions.md)                                 | F14     | migration (deps) | P2       | S      | LOW     | done   |
 | 004 | [Raise SDK runtime floors](004-raise-sdk-runtime-floors.md)                                                   | F15     | migration (deps) | P3       | S      | LOW     | done   |
 | 005 | [Fix knip config + remove dead searchLogs](005-fix-knip-config-and-remove-dead-searchlogs.md)                 | F10+F5  | tech-debt        | P2       | S      | LOW-MED | done   |
-| 006 | [Fix SSE backpressure dropping live events](006-fix-sse-backpressure-dropping-live-events.md)                 | F1      | bug              | P1       | S      | LOW     | todo   |
+| 006 | [Fix SSE backpressure dropping live events](006-fix-sse-backpressure-dropping-live-events.md)                 | F1      | bug              | P1       | S      | LOW     | done   |
 | 007 | [Fix OTLP zero-timestamp handling](007-fix-otlp-zero-timestamp.md)                                            | F17     | bug              | P2       | S      | LOW     | todo   |
 | 008 | [Harden fallback auth secret](008-harden-fallback-auth-secret.md)                                             | F6      | security         | P2       | S      | LOW     | done   |
 | 009 | [Tighten CSRF for cookie routes](009-tighten-csrf-for-cookie-routes.md)                                       | F16     | security         | P3       | S      | LOW     | done   |

--- a/src/routes/api/projects/[id]/incidents/stream/+server.ts
+++ b/src/routes/api/projects/[id]/incidents/stream/+server.ts
@@ -28,79 +28,85 @@ export async function POST(event: RequestEvent): Promise<Response> {
   const projectId = event.params.id;
   let cleanupFn: (() => void) | null = null;
 
-  const stream = new ReadableStream({
-    start(controller) {
-      const encoder = new TextEncoder();
-      let batch: Incident[] = [];
-      let flushTimeout: ReturnType<typeof setTimeout> | null = null;
-      let isClosed = false;
+  // Use a CountQueuingStrategy with a generous highWaterMark so normal
+  // ingest bursts never drive desiredSize to 0; genuine backpressure only
+  // triggers when the queue actually exceeds the mark (desiredSize < 0).
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        const encoder = new TextEncoder();
+        let batch: Incident[] = [];
+        let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+        let isClosed = false;
 
-      const sendEvent = (eventName: string, data: string): "sent" | "backpressure" | "closed" => {
-        if (isClosed) return "closed";
-        try {
-          const size = (controller as ReadableStreamDefaultController).desiredSize;
-          if (size !== null && size <= 0) {
-            // Stream backpressure: slow consumer — drop this event but keep the stream open
-            return "backpressure";
+        const sendEvent = (eventName: string, data: string): "sent" | "backpressure" | "closed" => {
+          if (isClosed) return "closed";
+          try {
+            const size = (controller as ReadableStreamDefaultController).desiredSize;
+            if (size !== null && size < 0) {
+              // Stream backpressure: slow consumer — drop this event but keep the stream open
+              return "backpressure";
+            }
+            controller.enqueue(encoder.encode(formatSSEEvent(eventName, data)));
+            return "sent";
+          } catch {
+            // Controller closed
+            return "closed";
           }
-          controller.enqueue(encoder.encode(formatSSEEvent(eventName, data)));
-          return "sent";
-        } catch {
-          // Controller closed
-          return "closed";
-        }
-      };
+        };
 
-      const flushBatch = () => {
-        if (batch.length > 0) {
-          // Only a closed controller is terminal; backpressure just drops this event.
-          if (sendEvent("incidents", JSON.stringify(batch)) === "closed") cleanup();
-          batch = [];
-        }
-        flushTimeout = null;
-      };
-
-      const handleIncident = (incident: Incident) => {
-        if (isClosed) return;
-        batch.push(incident);
-
-        if (!flushTimeout) {
-          flushTimeout = setTimeout(flushBatch, BATCH_WINDOW_MS);
-        }
-
-        if (batch.length >= MAX_BATCH_SIZE) {
-          if (flushTimeout) {
-            clearTimeout(flushTimeout);
-            flushTimeout = null;
+        const flushBatch = () => {
+          if (batch.length > 0) {
+            // Only a closed controller is terminal; backpressure just drops this event.
+            if (sendEvent("incidents", JSON.stringify(batch)) === "closed") cleanup();
+            batch = [];
           }
-          flushBatch();
-        }
-      };
+          flushTimeout = null;
+        };
 
-      const unsubscribe = logEventBus.onIncident(projectId, handleIncident);
-      const heartbeatInterval = setInterval(() => {
-        if (sendEvent("heartbeat", JSON.stringify({ ts: Date.now() })) === "closed") cleanup();
-      }, HEARTBEAT_INTERVAL_MS);
+        const handleIncident = (incident: Incident) => {
+          if (isClosed) return;
+          batch.push(incident);
 
-      const cleanup = () => {
-        if (isClosed) return;
-        isClosed = true;
-        unsubscribe();
-        clearInterval(heartbeatInterval);
-        if (flushTimeout) clearTimeout(flushTimeout);
-        try {
-          controller.close();
-        } catch {
-          // already closed
-        }
-      };
+          if (!flushTimeout) {
+            flushTimeout = setTimeout(flushBatch, BATCH_WINDOW_MS);
+          }
 
-      cleanupFn = cleanup;
+          if (batch.length >= MAX_BATCH_SIZE) {
+            if (flushTimeout) {
+              clearTimeout(flushTimeout);
+              flushTimeout = null;
+            }
+            flushBatch();
+          }
+        };
+
+        const unsubscribe = logEventBus.onIncident(projectId, handleIncident);
+        const heartbeatInterval = setInterval(() => {
+          if (sendEvent("heartbeat", JSON.stringify({ ts: Date.now() })) === "closed") cleanup();
+        }, HEARTBEAT_INTERVAL_MS);
+
+        const cleanup = () => {
+          if (isClosed) return;
+          isClosed = true;
+          unsubscribe();
+          clearInterval(heartbeatInterval);
+          if (flushTimeout) clearTimeout(flushTimeout);
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        };
+
+        cleanupFn = cleanup;
+      },
+      cancel() {
+        if (cleanupFn) cleanupFn();
+      },
     },
-    cancel() {
-      if (cleanupFn) cleanupFn();
-    },
-  });
+    new CountQueuingStrategy({ highWaterMark: 256 }),
+  );
 
   return new Response(stream, {
     status: 200,

--- a/src/routes/api/projects/[id]/logs/stream/+server.ts
+++ b/src/routes/api/projects/[id]/logs/stream/+server.ts
@@ -44,115 +44,122 @@ export async function POST(event: RequestEvent): Promise<Response> {
   // Store cleanup function outside the stream for cancel handler access
   let cleanupFn: (() => void) | null = null;
 
-  // Create a readable stream for SSE
-  const stream = new ReadableStream({
-    start(controller) {
-      const encoder = new TextEncoder();
+  // Create a readable stream for SSE.
+  // Use a CountQueuingStrategy with a generous highWaterMark so a 100-log
+  // burst (BATCH_INSERT_LIMIT) plus heartbeats never drive desiredSize to 0
+  // under normal operation, and genuine backpressure only triggers when the
+  // queue actually exceeds the mark (desiredSize < 0).
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        const encoder = new TextEncoder();
 
-      // Buffer for batching logs
-      let batch: Log[] = [];
-      let flushTimeout: ReturnType<typeof setTimeout> | null = null;
-      let isClosed = false;
+        // Buffer for batching logs
+        let batch: Log[] = [];
+        let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+        let isClosed = false;
 
-      /**
-       * Send an SSE event to the client.
-       * Returns 'sent' | 'backpressure' | 'closed'.
-       * Backpressure (slow consumer) drops the event but keeps the stream open.
-       * 'closed' means the controller has errored and the stream should be torn down.
-       */
-      const sendEvent = (eventName: string, data: string): "sent" | "backpressure" | "closed" => {
-        if (isClosed) return "closed";
-        try {
-          const size = (controller as ReadableStreamDefaultController).desiredSize;
-          if (size !== null && size <= 0) {
-            // Stream backpressure: slow consumer, drop the event but keep the stream alive
-            console.debug("[logs/stream] backpressure detected, dropping batch");
-            return "backpressure";
+        /**
+         * Send an SSE event to the client.
+         * Returns 'sent' | 'backpressure' | 'closed'.
+         * Backpressure (slow consumer) drops the event but keeps the stream open.
+         * 'closed' means the controller has errored and the stream should be torn down.
+         */
+        const sendEvent = (eventName: string, data: string): "sent" | "backpressure" | "closed" => {
+          if (isClosed) return "closed";
+          try {
+            const size = (controller as ReadableStreamDefaultController).desiredSize;
+            if (size !== null && size < 0) {
+              // Stream backpressure: slow consumer, drop the event but keep the stream alive
+              console.debug("[logs/stream] backpressure detected, dropping batch");
+              return "backpressure";
+            }
+            controller.enqueue(encoder.encode(formatSSEEvent(eventName, data)));
+            return "sent";
+          } catch {
+            // Controller closed or errored
+            return "closed";
           }
-          controller.enqueue(encoder.encode(formatSSEEvent(eventName, data)));
-          return "sent";
-        } catch {
-          // Controller closed or errored
-          return "closed";
-        }
-      };
+        };
 
-      /**
-       * Flush the current batch to the client
-       */
-      const flushBatch = () => {
-        if (batch.length > 0) {
-          const result = sendEvent("logs", JSON.stringify(batch));
+        /**
+         * Flush the current batch to the client
+         */
+        const flushBatch = () => {
+          if (batch.length > 0) {
+            const result = sendEvent("logs", JSON.stringify(batch));
+            if (result === "closed") {
+              cleanup();
+            }
+            // On 'backpressure', drop the batch but don't close the stream
+            batch = [];
+          }
+          flushTimeout = null;
+        };
+
+        /**
+         * Handler for incoming logs from event bus
+         */
+        const handleLog = (log: Log) => {
+          if (isClosed) return;
+          batch.push(log);
+
+          // Start batch timer if not already running
+          if (!flushTimeout) {
+            flushTimeout = setTimeout(flushBatch, BATCH_WINDOW_MS);
+          }
+
+          // Flush immediately if batch is full
+          if (batch.length >= MAX_BATCH_SIZE) {
+            if (flushTimeout) {
+              clearTimeout(flushTimeout);
+              flushTimeout = null;
+            }
+            flushBatch();
+          }
+        };
+
+        // Subscribe to log events for this project
+        const unsubscribe = logEventBus.onLog(projectId, handleLog);
+
+        // Set up heartbeat to keep connection alive
+        const heartbeatInterval = setInterval(() => {
+          const result = sendEvent("heartbeat", JSON.stringify({ ts: Date.now() }));
           if (result === "closed") {
             cleanup();
           }
-          // On 'backpressure', drop the batch but don't close the stream
-          batch = [];
-        }
-        flushTimeout = null;
-      };
+        }, HEARTBEAT_INTERVAL_MS);
 
-      /**
-       * Handler for incoming logs from event bus
-       */
-      const handleLog = (log: Log) => {
-        if (isClosed) return;
-        batch.push(log);
-
-        // Start batch timer if not already running
-        if (!flushTimeout) {
-          flushTimeout = setTimeout(flushBatch, BATCH_WINDOW_MS);
-        }
-
-        // Flush immediately if batch is full
-        if (batch.length >= MAX_BATCH_SIZE) {
+        /**
+         * Cleanup function to unsubscribe and clear timers
+         */
+        const cleanup = () => {
+          if (isClosed) return;
+          isClosed = true;
+          unsubscribe();
+          clearInterval(heartbeatInterval);
           if (flushTimeout) {
             clearTimeout(flushTimeout);
-            flushTimeout = null;
           }
-          flushBatch();
-        }
-      };
+          try {
+            controller.close();
+          } catch {
+            // Already closed
+          }
+        };
 
-      // Subscribe to log events for this project
-      const unsubscribe = logEventBus.onLog(projectId, handleLog);
-
-      // Set up heartbeat to keep connection alive
-      const heartbeatInterval = setInterval(() => {
-        const result = sendEvent("heartbeat", JSON.stringify({ ts: Date.now() }));
-        if (result === "closed") {
-          cleanup();
+        // Store cleanup for cancel handler
+        cleanupFn = cleanup;
+      },
+      cancel() {
+        // Called when client disconnects
+        if (cleanupFn) {
+          cleanupFn();
         }
-      }, HEARTBEAT_INTERVAL_MS);
-
-      /**
-       * Cleanup function to unsubscribe and clear timers
-       */
-      const cleanup = () => {
-        if (isClosed) return;
-        isClosed = true;
-        unsubscribe();
-        clearInterval(heartbeatInterval);
-        if (flushTimeout) {
-          clearTimeout(flushTimeout);
-        }
-        try {
-          controller.close();
-        } catch {
-          // Already closed
-        }
-      };
-
-      // Store cleanup for cancel handler
-      cleanupFn = cleanup;
+      },
     },
-    cancel() {
-      // Called when client disconnects
-      if (cleanupFn) {
-        cleanupFn();
-      }
-    },
-  });
+    new CountQueuingStrategy({ highWaterMark: 256 }),
+  );
 
   return new Response(stream, {
     status: 200,

--- a/tests/integration/api/projects/[id]/logs/stream/server.integration.test.ts
+++ b/tests/integration/api/projects/[id]/logs/stream/server.integration.test.ts
@@ -390,6 +390,32 @@ describe("POST /api/projects/[id]/logs/stream", () => {
       expect(logs.some((l: Log) => l.message === "Batch log 3")).toBe(true);
     });
 
+    it("delivers all logs when a burst exceeds the batch size", async () => {
+      const project = await seedProject(db, { ownerId: userId });
+      const request = new Request(`http://localhost/api/projects/${project.id}/logs/stream`, {
+        method: "POST",
+      });
+      const event = createRequestEvent(request, db, { id: project.id }, true);
+      const { POST } =
+        await import("../../../../../../../src/routes/api/projects/[id]/logs/stream/+server");
+      const response = await POST(event as never);
+
+      await new Promise((r) => setTimeout(r, 50)); // let subscription set up
+
+      const TOTAL = 100;
+      for (let i = 0; i < TOTAL; i++) {
+        logEventBus.emitLog(createMockLog(project.id, { message: `burst ${i}` }));
+      }
+
+      // Collect enough events to cover all batches (first flush is 50, remainder follow)
+      const events = await collectSSEEvents(response, 5, 3000);
+      const received = events
+        .filter((e) => e.event === "logs")
+        .flatMap((e) => JSON.parse(e.data) as Log[]);
+
+      expect(received.length).toBe(TOTAL);
+    });
+
     it("flushes immediately when batch reaches 50 logs", async () => {
       const project = await seedProject(db, { ownerId: userId });
 


### PR DESCRIPTION
## Plan 006 — Stop SSE streams from silently dropping live events on bursts >50 (finding F1, **P1**)

A default `ReadableStream` has `highWaterMark = 1`, so `controller.desiredSize` hits `0` right after the first `enqueue()`. The SSE code treated `desiredSize <= 0` as backpressure and **dropped the batch**. On the ingest path, logs are emitted to the bus synchronously, so a single ingest of 51–100 logs flushed the first ≤50 then **dropped everything after** — live viewers lost data exactly when there was most to show.

### Changes (both stream files, kept in lockstep)
- Construct `ReadableStream` with `new CountQueuingStrategy({ highWaterMark: 256 })` — ample headroom over a 100-log burst, still bounded for a truly stalled consumer.
- Backpressure threshold `size <= 0` → `size < 0`, so the normal resting `desiredSize === 0` no longer drops events; only a genuinely over-full queue (negative) is treated as backpressure.
- **tests/integration/.../logs/stream/server.integration.test.ts**: new burst test emits 100 logs synchronously, asserts all 100 received.
- **plans/README.md**: plan 006 status → `done`.

### Why it's correct (regression-proven)
Reverting the source (keeping the test) makes the new test **fail** with `expected 50 to be 100` and logs "backpressure detected, dropping batch" — exactly the bug. With the fix: 100/100 received. Genuine backpressure for stalled consumers is preserved (`desiredSize < 0`). Ingest emit loop, event bus, and `MAX_BATCH_SIZE` are untouched (deeper coalescing deferred to a tech-debt plan, per the plan's note).

### Verification
- `test:integration -- logs/stream` 10/10 (incl. burst); full `test:integration` 307/307
- `vp check` 0, `bun run check` 0

This builds on plan 011's incidents-stream regression net (already merged). Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
