### PR TITLE
test(ingest): assert 429 rate-limit wiring on /v1/ingest and /v1/logs (F8)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -32,7 +32,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 007 | [Fix OTLP zero-timestamp handling](007-fix-otlp-zero-timestamp.md)                                            | F17     | bug              | P2       | S      | LOW     | todo   |
 | 008 | [Harden fallback auth secret](008-harden-fallback-auth-secret.md)                                             | F6      | security         | P2       | S      | LOW     | done   |
 | 009 | [Tighten CSRF for cookie routes](009-tighten-csrf-for-cookie-routes.md)                                       | F16     | security         | P3       | S      | LOW     | done   |
-| 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | todo   |
+| 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | done   |
 | 011 | [Test incidents SSE stream](011-test-incidents-sse-stream.md)                                                 | F9      | tests            | P2       | M      | LOW     | done   |
 | 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | todo   |
 | 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | todo   |

--- a/tests/integration/otlp/logs.integration.test.ts
+++ b/tests/integration/otlp/logs.integration.test.ts
@@ -7,6 +7,7 @@ import { incident, log, project as projectTable } from "../../../src/lib/server/
 import { setupTestDatabase } from "../../../src/lib/server/db/test-db";
 import { logEventBus } from "../../../src/lib/server/events";
 import { clearApiKeyCache, validateApiKey } from "../../../src/lib/server/utils/api-key";
+import { checkRateLimit, INGEST_RPM } from "../../../src/lib/server/utils/rate-limit";
 import { POST } from "../../../src/routes/v1/logs/+server";
 import { seedProjectWithApiKey } from "../../fixtures/db";
 
@@ -491,6 +492,105 @@ describe("POST /v1/logs (OTLP)", () => {
       expect(response.status).toBe(401);
       const body = await response.json();
       expect(body.error).toBe("unauthorized");
+    });
+  });
+
+  describe("Rate limiting", () => {
+    it("returns 429 with Retry-After when bucket is exhausted, and writes no logs", async () => {
+      // Fresh project = fresh bucket key; no bleed from other tests
+      const project = await seedProjectWithApiKey(db);
+
+      // Drain the bucket for this project key directly via the same module-level map
+      while (checkRateLimit(`ingest:${project.id}`, INGEST_RPM)) {
+        // keep consuming tokens until the bucket is empty
+      }
+
+      const payload = {
+        resourceLogs: [
+          {
+            scopeLogs: [
+              {
+                logRecords: [{ body: { stringValue: "should be rate limited" } }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const request = new Request("http://localhost/v1/logs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${project.apiKey}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const event = createRequestEvent(request, db);
+      const response = await POST(event as never);
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).toBe("60");
+      const body = await response.json();
+      expect(body.error).toBe("rate_limited");
+
+      // Confirm nothing was written to the DB
+      const rows = await db.select().from(log).where(eq(log.projectId, project.id));
+      expect(rows.length).toBe(0);
+    });
+
+    it("limits key A but allows key B (per-project isolation)", async () => {
+      const projectA = await seedProjectWithApiKey(db);
+      const projectB = await seedProjectWithApiKey(db);
+
+      // Drain only project A's bucket
+      while (checkRateLimit(`ingest:${projectA.id}`, INGEST_RPM)) {
+        // consume until empty
+      }
+
+      const otlpPayload = (message: string) => ({
+        resourceLogs: [
+          {
+            scopeLogs: [
+              {
+                logRecords: [{ body: { stringValue: message } }],
+              },
+            ],
+          },
+        ],
+      });
+
+      // Project A should now be rate limited
+      const requestA = new Request("http://localhost/v1/logs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${projectA.apiKey}`,
+        },
+        body: JSON.stringify(otlpPayload("A limited")),
+      });
+      const eventA = createRequestEvent(requestA, db);
+      const responseA = await POST(eventA as never);
+      expect(responseA.status).toBe(429);
+
+      // Project B should still be allowed
+      const requestB = new Request("http://localhost/v1/logs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${projectB.apiKey}`,
+        },
+        body: JSON.stringify(otlpPayload("B allowed")),
+      });
+      const eventB = createRequestEvent(requestB, db);
+      const responseB = await POST(eventB as never);
+      expect(responseB.status).toBe(200);
+
+      // Confirm one log was written for B, none for A
+      const rowsA = await db.select().from(log).where(eq(log.projectId, projectA.id));
+      const rowsB = await db.select().from(log).where(eq(log.projectId, projectB.id));
+      expect(rowsA.length).toBe(0);
+      expect(rowsB.length).toBe(1);
     });
   });
 });

--- a/tests/integration/simple-ingest/logs.integration.test.ts
+++ b/tests/integration/simple-ingest/logs.integration.test.ts
@@ -7,6 +7,7 @@ import { incident, log, project as projectTable } from "../../../src/lib/server/
 import { setupTestDatabase } from "../../../src/lib/server/db/test-db";
 import { logEventBus } from "../../../src/lib/server/events";
 import { clearApiKeyCache, validateApiKey } from "../../../src/lib/server/utils/api-key";
+import { checkRateLimit, INGEST_RPM } from "../../../src/lib/server/utils/rate-limit";
 import { POST } from "../../../src/routes/v1/ingest/+server";
 import { seedProjectWithApiKey } from "../../fixtures/db";
 
@@ -604,6 +605,81 @@ describe("POST /v1/ingest (Simple API)", () => {
       expect(response.status).toBe(401);
       const body = await response.json();
       expect(body.error).toBe("unauthorized");
+    });
+  });
+
+  describe("Rate limiting", () => {
+    it("returns 429 with Retry-After when bucket is exhausted, and writes no logs", async () => {
+      // Fresh project = fresh bucket key; no bleed from other tests
+      const project = await seedProjectWithApiKey(db);
+
+      // Drain the bucket for this project key directly via the same module-level map
+      while (checkRateLimit(`ingest:${project.id}`, INGEST_RPM)) {
+        // keep consuming tokens until the bucket is empty
+      }
+
+      const request = new Request("http://localhost/v1/ingest", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${project.apiKey}`,
+        },
+        body: JSON.stringify({ level: "info", message: "should be rate limited" }),
+      });
+
+      const event = createRequestEvent(request, db);
+      const response = await POST(event as never);
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).toBe("60");
+      const body = await response.json();
+      expect(body.error).toBe("rate_limited");
+
+      // Confirm nothing was written to the DB
+      const rows = await db.select().from(log).where(eq(log.projectId, project.id));
+      expect(rows.length).toBe(0);
+    });
+
+    it("limits key A but allows key B (per-project isolation)", async () => {
+      const projectA = await seedProjectWithApiKey(db);
+      const projectB = await seedProjectWithApiKey(db);
+
+      // Drain only project A's bucket
+      while (checkRateLimit(`ingest:${projectA.id}`, INGEST_RPM)) {
+        // consume until empty
+      }
+
+      // Project A should now be rate limited
+      const requestA = new Request("http://localhost/v1/ingest", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${projectA.apiKey}`,
+        },
+        body: JSON.stringify({ level: "info", message: "A limited" }),
+      });
+      const eventA = createRequestEvent(requestA, db);
+      const responseA = await POST(eventA as never);
+      expect(responseA.status).toBe(429);
+
+      // Project B should still be allowed
+      const requestB = new Request("http://localhost/v1/ingest", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${projectB.apiKey}`,
+        },
+        body: JSON.stringify({ level: "info", message: "B allowed" }),
+      });
+      const eventB = createRequestEvent(requestB, db);
+      const responseB = await POST(eventB as never);
+      expect(responseB.status).toBe(200);
+
+      // Confirm one log was written for B, none for A
+      const rowsA = await db.select().from(log).where(eq(log.projectId, projectA.id));
+      const rowsB = await db.select().from(log).where(eq(log.projectId, projectB.id));
+      expect(rowsA.length).toBe(0);
+      expect(rowsB.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Plan 010 — Integration tests proving rate-limit 429 wiring on the ingest endpoints (finding F8)

The token-bucket limiter is unit-tested, but nothing proved the endpoints actually *call* it. A refactor could silently drop the guard and every existing test would still pass. These tests lock the wiring in place.

### Changes (test-only)
- **tests/integration/simple-ingest/logs.integration.test.ts** + **tests/integration/otlp/logs.integration.test.ts**: each gains a `Rate limiting` describe with:
  - **drain-then-429**: exhausts the project's token bucket via `checkRateLimit(...)` in a loop, sends a valid ingest request, asserts `429` + `Retry-After: 60` + `error: rate_limited` + **zero logs written**.
  - **per-key isolation**: drains project A's bucket → A gets 429 while project B still succeeds (200, 1 row).
  - Each test seeds a fresh project (fresh bucket key) → order-independent, no cross-test bleed.
- The divergent 429 body shapes are intentionally preserved (`/v1/ingest` → `{error,message}`, `/v1/logs` → `{error}`); each test asserts only its endpoint's actual shape (the normalization nit stays a recorded minor item).
- **plans/README.md**: plan 010 status → `done`.

### Verification
- `test:integration -- simple-ingest` 22/22; `-- otlp` 13/13; full `test:integration` 311/311 (deterministic on re-run)
- **Mutation-proven**: disabling the rate-limit guard in `/v1/ingest` makes the new tests fail (429→200), then reverted.
- `vp check` 0, `bun run check` 0.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
