### PR TITLE
fix(otlp): treat zero timeUnixNano as unset so observedTime/now win (F17)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -29,7 +29,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 004 | [Raise SDK runtime floors](004-raise-sdk-runtime-floors.md)                                                   | F15     | migration (deps) | P3       | S      | LOW     | done   |
 | 005 | [Fix knip config + remove dead searchLogs](005-fix-knip-config-and-remove-dead-searchlogs.md)                 | F10+F5  | tech-debt        | P2       | S      | LOW-MED | done   |
 | 006 | [Fix SSE backpressure dropping live events](006-fix-sse-backpressure-dropping-live-events.md)                 | F1      | bug              | P1       | S      | LOW     | done   |
-| 007 | [Fix OTLP zero-timestamp handling](007-fix-otlp-zero-timestamp.md)                                            | F17     | bug              | P2       | S      | LOW     | todo   |
+| 007 | [Fix OTLP zero-timestamp handling](007-fix-otlp-zero-timestamp.md)                                            | F17     | bug              | P2       | S      | LOW     | done   |
 | 008 | [Harden fallback auth secret](008-harden-fallback-auth-secret.md)                                             | F6      | security         | P2       | S      | LOW     | done   |
 | 009 | [Tighten CSRF for cookie routes](009-tighten-csrf-for-cookie-routes.md)                                       | F16     | security         | P3       | S      | LOW     | done   |
 | 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | done   |

--- a/src/lib/server/utils/otlp.ts
+++ b/src/lib/server/utils/otlp.ts
@@ -129,8 +129,14 @@ function parseIntValue(value: unknown): number | string | null {
   return null;
 }
 
+function nonZeroNano(value: string | null): string | null {
+  // Treat an explicit zero ("0", "00", ...) as unset so observedTime / now() win.
+  if (value === null) return null;
+  return /^0+$/.test(value) ? null : value;
+}
+
 function parseTimestamp(timeUnixNano: string | null, observedTimeUnixNano: string | null): Date {
-  const candidate = timeUnixNano ?? observedTimeUnixNano;
+  const candidate = nonZeroNano(timeUnixNano) ?? nonZeroNano(observedTimeUnixNano);
   if (!candidate) {
     return new Date();
   }

--- a/src/lib/server/utils/otlp.unit.test.ts
+++ b/src/lib/server/utils/otlp.unit.test.ts
@@ -179,6 +179,112 @@ describe("parseUint64String", () => {
   });
 });
 
+describe("zero timeUnixNano handling", () => {
+  it('treats timeUnixNano "0" as unset and uses observedTimeUnixNano instead', () => {
+    // observedTimeUnixNano corresponds to 2023-11-14T22:13:20.000Z (1700000000000 ms)
+    const payload = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: "0",
+                  observedTimeUnixNano: "1700000000000000000",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { records } = normalizeOtlpLogsRequest(payload);
+    expect(records).toHaveLength(1);
+    const record = records[0]!;
+    // The raw stored column should still be "0" (unchanged by the fix)
+    expect(record.timeUnixNano).toBe("0");
+    // The derived timestamp must NOT be epoch 1970 — it should equal observedTimeUnixNano
+    expect(record.timestamp.toISOString()).toBe(new Date(1700000000000).toISOString());
+  });
+
+  it("treats timeUnixNano 0 (number) as unset and uses observedTimeUnixNano instead", () => {
+    const payload = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: 0,
+                  observedTimeUnixNano: "1700000000000000000",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { records } = normalizeOtlpLogsRequest(payload);
+    expect(records).toHaveLength(1);
+    const record = records[0]!;
+    // parseUint64String(0) returns "0"; nonZeroNano maps it to null
+    expect(record.timestamp.toISOString()).toBe(new Date(1700000000000).toISOString());
+  });
+
+  it('treats timeUnixNano "0" and missing observedTimeUnixNano as ~now (not epoch)', () => {
+    const before = Date.now();
+    const payload = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: "0",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { records } = normalizeOtlpLogsRequest(payload);
+    const after = Date.now();
+    expect(records).toHaveLength(1);
+    const ts = records[0]!.timestamp.getTime();
+    expect(ts).toBeGreaterThanOrEqual(before - 1000);
+    expect(ts).toBeLessThanOrEqual(after + 1000);
+    // Must NOT be epoch 0 (1970)
+    expect(ts).toBeGreaterThan(1_000_000_000_000);
+  });
+
+  it("regression: valid non-zero timeUnixNano still produces the correct date", () => {
+    const payload = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: "1700000000000000000",
+                  observedTimeUnixNano: "1700000000001000000",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { records } = normalizeOtlpLogsRequest(payload);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.timestamp.toISOString()).toBe(new Date(1700000000000).toISOString());
+  });
+});
+
 describe("normalizeOtlpLogsRequest edge cases", () => {
   it("rejects negative timeUnixNano and falls back to current timestamp", () => {
     const payload = {


### PR DESCRIPTION
## Plan 007 — Treat OTLP `timeUnixNano` of zero as "unset" (finding F17)

When an OTLP exporter sends `timeUnixNano: "0"` (a non-conformant but real "unset" representation), Logwell stored the log at `1970-01-01T00:00:00Z` — `"0"` passed the uint64 validation, shadowed the valid `observedTimeUnixNano` fallback, and `new Date(0)` isn't `NaN`. Such logs sort to the bottom, fall outside time-range/timeline queries, and become immediately eligible for retention deletion.

### Changes (narrow, at the timestamp-derivation boundary)
- **src/lib/server/utils/otlp.ts**: new `nonZeroNano(value)` helper maps an all-zero nano string (`"0"`, `"00"`, …) to `null`; `parseTimestamp` now does `nonZeroNano(timeUnixNano) ?? nonZeroNano(observedTimeUnixNano)`. So zero `timeUnixNano` falls through to `observedTime`, and zero-or-absent on both falls through to `new Date()` (now).
- **Deliberately NOT changed**: `parseUint64String` still accepts `"0"` for the *raw stored columns* — a zero is still persisted as `"0"` in `timeUnixNano`; only the *derived* `timestamp` changed (the test locks this in).
- **otlp.unit.test.ts**: 4 new cases (zero+observed→observed; zero number+observed→observed; zero+none→~now; non-zero regression).
- **plans/README.md**: plan 007 status → `done`.

### Verification
- `test:unit -- otlp` 21/21; `test:integration -- otlp` 13/13; full unit 338/338
- **Negative-control proven**: reverting the fix makes 3 of the 4 new tests fail.
- `vp check` 0, `bun run check` 0.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
