### PR TITLE
perf(ingest): batch incident upsert and drop tsvector from returning (F3, F7)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -34,7 +34,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 009 | [Tighten CSRF for cookie routes](009-tighten-csrf-for-cookie-routes.md)                                       | F16     | security         | P3       | S      | LOW     | done   |
 | 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | done   |
 | 011 | [Test incidents SSE stream](011-test-incidents-sse-stream.md)                                                 | F9      | tests            | P2       | M      | LOW     | done   |
-| 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | todo   |
+| 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | done   |
 | 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | todo   |
 | 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | todo   |
 | 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | todo   |

--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -1,6 +1,13 @@
 import type { Incident, Log } from "./db/schema";
 
-export type LogListener = (log: Log) => void;
+/**
+ * Log shape emitted on the event bus — every column except the generated
+ * `search` tsvector, which is never used by SSE consumers and would bloat
+ * the JSON payload unnecessarily.
+ */
+export type StreamLog = Omit<Log, "search">;
+
+export type LogListener = (log: StreamLog) => void;
 export type IncidentListener = (incident: Incident) => void;
 
 /**
@@ -39,9 +46,9 @@ class LogEventBus {
 
   /**
    * Emit a log event to all listeners subscribed to its project.
-   * @param log - The log entry to emit
+   * @param log - The log entry to emit (search tsvector excluded)
    */
-  emitLog(log: Log): void {
+  emitLog(log: StreamLog): void {
     const projectListeners = this.listeners.get(log.projectId);
     if (projectListeners) {
       for (const listener of projectListeners) {

--- a/src/lib/server/utils/incidents.ts
+++ b/src/lib/server/utils/incidents.ts
@@ -197,11 +197,11 @@ export async function upsertIncidentsForPreparedLogs(
   const incidentByFingerprint = new Map<string, Incident>();
   const touchedIncidents: Incident[] = [];
 
-  for (const aggregate of aggregates) {
-    const now = new Date();
-    const [result] = await db
-      .insert(incident)
-      .values({
+  const now = new Date();
+  const rows = await db
+    .insert(incident)
+    .values(
+      aggregates.map((aggregate) => ({
         id: nanoid(),
         projectId,
         fingerprint: aggregate.fingerprint,
@@ -216,30 +216,29 @@ export async function upsertIncidentsForPreparedLogs(
         totalEvents: aggregate.totalEvents,
         createdAt: now,
         updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [incident.projectId, incident.fingerprint],
-        set: {
-          highestLevel: sql`(
+      })),
+    )
+    .onConflictDoUpdate({
+      target: [incident.projectId, incident.fingerprint],
+      set: {
+        highestLevel: sql`(
             CASE
               WHEN ${incident.highestLevel}::text = 'fatal' OR excluded.highest_level::text = 'fatal'
                 THEN 'fatal'
               ELSE 'error'
             END
           )::log_level`,
-          firstSeen: sql`LEAST(${incident.firstSeen}, excluded.first_seen)`,
-          lastSeen: sql`GREATEST(${incident.lastSeen}, excluded.last_seen)`,
-          totalEvents: sql`${incident.totalEvents} + excluded.total_events`,
-          updatedAt: now,
-        },
-      })
-      .returning();
+        firstSeen: sql`LEAST(${incident.firstSeen}, excluded.first_seen)`,
+        lastSeen: sql`GREATEST(${incident.lastSeen}, excluded.last_seen)`,
+        totalEvents: sql`${incident.totalEvents} + excluded.total_events`,
+        updatedAt: now,
+      },
+    })
+    .returning();
 
-    if (!result) {
-      throw new Error(`Incident upsert returned no row for fingerprint: ${aggregate.fingerprint}`);
-    }
-    incidentByFingerprint.set(aggregate.fingerprint, result);
-    touchedIncidents.push(result);
+  for (const row of rows) {
+    incidentByFingerprint.set(row.fingerprint, row);
+    touchedIncidents.push(row);
   }
 
   return { incidentByFingerprint, touchedIncidents };

--- a/src/routes/api/projects/[id]/logs/stream/+server.ts
+++ b/src/routes/api/projects/[id]/logs/stream/+server.ts
@@ -1,6 +1,5 @@
 import { SSE_CONFIG } from "$lib/server/config/performance";
-import type { Log } from "$lib/server/db/schema";
-import { logEventBus } from "$lib/server/events";
+import { logEventBus, type StreamLog } from "$lib/server/events";
 import { checkCsrfOrigin } from "$lib/server/utils/csrf";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
 import type { RequestEvent } from "./$types";
@@ -55,7 +54,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
         const encoder = new TextEncoder();
 
         // Buffer for batching logs
-        let batch: Log[] = [];
+        let batch: StreamLog[] = [];
         let flushTimeout: ReturnType<typeof setTimeout> | null = null;
         let isClosed = false;
 
@@ -100,7 +99,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
         /**
          * Handler for incoming logs from event bus
          */
-        const handleLog = (log: Log) => {
+        const handleLog = (log: StreamLog) => {
           if (isClosed) return;
           batch.push(log);
 

--- a/src/routes/v1/ingest/+server.ts
+++ b/src/routes/v1/ingest/+server.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { API_CONFIG } from "$lib/server/config/performance";
 import { getDbClient } from "$lib/server/db/db";
 import { log, project } from "$lib/server/db/schema";
-import { logEventBus } from "$lib/server/events";
+import { logEventBus, type StreamLog } from "$lib/server/events";
 import { ApiKeyError, validateApiKey } from "$lib/server/utils/api-key";
 import { requireJsonContentType } from "$lib/server/utils/content-type";
 import {
@@ -168,7 +168,46 @@ export const POST: RequestHandler = async ({ request, locals }) => {
             };
           });
 
-          const insertedLogs = await tx.insert(log).values(logEntries).returning();
+          // The union DatabaseClient type prevents TypeScript from resolving the
+          // .returning(fields) overload on the transaction builder. The cast is
+          // necessary; the explicit column map is the source of truth and
+          // ensures `search` (the generated tsvector) is never fetched.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const insertedLogs: StreamLog[] = await (
+            tx.insert(log).values(logEntries) as any
+          ).returning({
+            id: log.id,
+            projectId: log.projectId,
+            incidentId: log.incidentId,
+            fingerprint: log.fingerprint,
+            serviceName: log.serviceName,
+            level: log.level,
+            message: log.message,
+            metadata: log.metadata,
+            timeUnixNano: log.timeUnixNano,
+            observedTimeUnixNano: log.observedTimeUnixNano,
+            severityNumber: log.severityNumber,
+            severityText: log.severityText,
+            body: log.body,
+            droppedAttributesCount: log.droppedAttributesCount,
+            flags: log.flags,
+            traceId: log.traceId,
+            spanId: log.spanId,
+            resourceAttributes: log.resourceAttributes,
+            resourceDroppedAttributesCount: log.resourceDroppedAttributesCount,
+            resourceSchemaUrl: log.resourceSchemaUrl,
+            scopeName: log.scopeName,
+            scopeVersion: log.scopeVersion,
+            scopeAttributes: log.scopeAttributes,
+            scopeDroppedAttributesCount: log.scopeDroppedAttributesCount,
+            scopeSchemaUrl: log.scopeSchemaUrl,
+            sourceFile: log.sourceFile,
+            lineNumber: log.lineNumber,
+            requestId: log.requestId,
+            userId: log.userId,
+            ipAddress: log.ipAddress,
+            timestamp: log.timestamp,
+          });
           return { insertedLogs, touchedIncidents };
         })
       : { insertedLogs: [], touchedIncidents: [] };

--- a/src/routes/v1/logs/+server.ts
+++ b/src/routes/v1/logs/+server.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { API_CONFIG } from "$lib/server/config/performance";
 import { getDbClient } from "$lib/server/db/db";
 import { log, project } from "$lib/server/db/schema";
-import { logEventBus } from "$lib/server/events";
+import { logEventBus, type StreamLog } from "$lib/server/events";
 import { ApiKeyError, validateApiKey } from "$lib/server/utils/api-key";
 import { requireJsonContentType } from "$lib/server/utils/content-type";
 import {
@@ -165,7 +165,46 @@ export const POST: RequestHandler = async ({ request, locals }) => {
             };
           });
 
-          const insertedLogs = await tx.insert(log).values(logEntries).returning();
+          // The union DatabaseClient type prevents TypeScript from resolving the
+          // .returning(fields) overload on the transaction builder. The cast is
+          // necessary; the explicit column map is the source of truth and
+          // ensures `search` (the generated tsvector) is never fetched.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const insertedLogs: StreamLog[] = await (
+            tx.insert(log).values(logEntries) as any
+          ).returning({
+            id: log.id,
+            projectId: log.projectId,
+            incidentId: log.incidentId,
+            fingerprint: log.fingerprint,
+            serviceName: log.serviceName,
+            level: log.level,
+            message: log.message,
+            metadata: log.metadata,
+            timeUnixNano: log.timeUnixNano,
+            observedTimeUnixNano: log.observedTimeUnixNano,
+            severityNumber: log.severityNumber,
+            severityText: log.severityText,
+            body: log.body,
+            droppedAttributesCount: log.droppedAttributesCount,
+            flags: log.flags,
+            traceId: log.traceId,
+            spanId: log.spanId,
+            resourceAttributes: log.resourceAttributes,
+            resourceDroppedAttributesCount: log.resourceDroppedAttributesCount,
+            resourceSchemaUrl: log.resourceSchemaUrl,
+            scopeName: log.scopeName,
+            scopeVersion: log.scopeVersion,
+            scopeAttributes: log.scopeAttributes,
+            scopeDroppedAttributesCount: log.scopeDroppedAttributesCount,
+            scopeSchemaUrl: log.scopeSchemaUrl,
+            sourceFile: log.sourceFile,
+            lineNumber: log.lineNumber,
+            requestId: log.requestId,
+            userId: log.userId,
+            ipAddress: log.ipAddress,
+            timestamp: log.timestamp,
+          });
           return { insertedLogs, touchedIncidents };
         })
       : { insertedLogs: [], touchedIncidents: [] };

--- a/tests/integration/utils/incidents.upsert.integration.test.ts
+++ b/tests/integration/utils/incidents.upsert.integration.test.ts
@@ -139,4 +139,119 @@ describe("Incident upsert race condition", () => {
 
     expect(allIncidents).toHaveLength(2);
   });
+
+  it("batches multiple distinct fingerprints in a single upsert call", async () => {
+    const project = await seedProject(db);
+    const now = new Date();
+
+    // Two distinct fingerprints each appearing twice, plus one appearing once
+    const logs: PreparedIncidentLog[] = [
+      {
+        level: "error",
+        message: "Cache miss",
+        timestamp: now,
+        sourceFile: "src/cache.ts",
+        lineNumber: 10,
+        resourceAttributes: null,
+        metadata: null,
+        serviceName: "cache-svc",
+        fingerprint: "fp-cache",
+        normalizedMessage: "cache miss",
+        incidentTitle: "Cache miss",
+        incidentId: null,
+      },
+      {
+        level: "error",
+        message: "DB timeout",
+        timestamp: new Date(now.getTime() + 500),
+        sourceFile: "src/db.ts",
+        lineNumber: 20,
+        resourceAttributes: null,
+        metadata: null,
+        serviceName: "db-svc",
+        fingerprint: "fp-db",
+        normalizedMessage: "db timeout",
+        incidentTitle: "DB timeout",
+        incidentId: null,
+      },
+      {
+        level: "fatal",
+        message: "Auth failure",
+        timestamp: new Date(now.getTime() + 1000),
+        sourceFile: "src/auth.ts",
+        lineNumber: 30,
+        resourceAttributes: null,
+        metadata: null,
+        serviceName: "auth-svc",
+        fingerprint: "fp-auth",
+        normalizedMessage: "auth failure",
+        incidentTitle: "Auth failure",
+        incidentId: null,
+      },
+      // repeat fp-cache and fp-db to accumulate totalEvents
+      {
+        level: "error",
+        message: "Cache miss again",
+        timestamp: new Date(now.getTime() + 1500),
+        sourceFile: "src/cache.ts",
+        lineNumber: 10,
+        resourceAttributes: null,
+        metadata: null,
+        serviceName: "cache-svc",
+        fingerprint: "fp-cache",
+        normalizedMessage: "cache miss",
+        incidentTitle: "Cache miss",
+        incidentId: null,
+      },
+      {
+        level: "error",
+        message: "DB timeout again",
+        timestamp: new Date(now.getTime() + 2000),
+        sourceFile: "src/db.ts",
+        lineNumber: 20,
+        resourceAttributes: null,
+        metadata: null,
+        serviceName: "db-svc",
+        fingerprint: "fp-db",
+        normalizedMessage: "db timeout",
+        incidentTitle: "DB timeout",
+        incidentId: null,
+      },
+    ];
+
+    const result = await upsertIncidentsForPreparedLogs(db, project.id, logs);
+
+    // Three distinct fingerprints → three incident rows
+    expect(result.touchedIncidents).toHaveLength(3);
+    expect(result.incidentByFingerprint.size).toBe(3);
+    expect(result.incidentByFingerprint.has("fp-cache")).toBe(true);
+    expect(result.incidentByFingerprint.has("fp-db")).toBe(true);
+    expect(result.incidentByFingerprint.has("fp-auth")).toBe(true);
+
+    const allIncidents = await db
+      .select()
+      .from(schema.incident)
+      .where(eq(schema.incident.projectId, project.id));
+
+    expect(allIncidents).toHaveLength(3);
+
+    const cacheIncident = allIncidents.find((i) => i.fingerprint === "fp-cache")!;
+    const dbIncident = allIncidents.find((i) => i.fingerprint === "fp-db")!;
+    const authIncident = allIncidents.find((i) => i.fingerprint === "fp-auth")!;
+
+    // fp-cache appeared twice → totalEvents = 2
+    expect(cacheIncident.totalEvents).toBe(2);
+    // fp-db appeared twice → totalEvents = 2
+    expect(dbIncident.totalEvents).toBe(2);
+    // fp-auth appeared once → totalEvents = 1
+    expect(authIncident.totalEvents).toBe(1);
+
+    // fatal-level fp-auth must have highestLevel = 'fatal'
+    expect(authIncident.highestLevel).toBe("fatal");
+    // error-level fp-cache must have highestLevel = 'error'
+    expect(cacheIncident.highestLevel).toBe("error");
+
+    // lastSeen for fp-cache should equal the second occurrence timestamp
+    expect(cacheIncident.lastSeen.getTime()).toBe(now.getTime() + 1500);
+  });
 });


### PR DESCRIPTION
## Plan 012 — Batch the incident upsert + narrow the log `.returning()` on the ingest hot path (findings F3, F7)

Two inefficiencies on the hottest write path (log ingestion):
1. **N+1 incident upsert** — one `INSERT … ON CONFLICT … RETURNING` per distinct fingerprint, awaited sequentially while holding the ingest transaction open (up to 100 round-trips/batch).
2. **Over-fetching `.returning()`** — `RETURNING *` pulled the large generated `search` tsvector (never used) for up to 100 rows and shipped them to every SSE client.

### Changes
- **incidents.ts**: the per-fingerprint `await` loop → **one multi-row** `INSERT … ON CONFLICT DO UPDATE … RETURNING`. SET semantics (fatal-escalation CASE / `LEAST(firstSeen)` / `GREATEST(lastSeen)` / `totalEvents + excluded.total_events`) are **byte-for-byte preserved** (`groupPreparedLogsByFingerprint` guarantees distinct fingerprints, so no intra-batch ON CONFLICT).
- **events.ts**: `StreamLog = Omit<Log, "search">`; `emitLog`/`LogListener` use it so no consumer can read the absent tsvector.
- **v1/ingest** + **v1/logs**: `.returning()` → explicit 31-column projection excluding `search`.
- **logs/stream/+server.ts**: `handleLog`/batch typed `StreamLog`.
- **incidents.upsert.integration.test.ts**: new multi-fingerprint single-batch test.
- **plans/README.md**: plan 012 status → `done`.

### Deviation (called out)
The narrowed `.returning({...})` required `(tx.insert(log).values(...) as any).returning({...})` — the `PostgresJsDatabase | PgliteDatabase` union type makes TS resolve only the zero-arg `.returning()` overload (verified: `tsc` errors TS2554 without the cast). The cast is on the **builder only**; the result is annotated `StreamLog[]`, so consumer type-safety (no `search` access) is preserved. Documented inline with an eslint-disable.

### Verification
- `test:integration` 312/312 (incidents 25, ingest 22+13, stream 17); `test:unit` 338
- **Mutation-proven**: breaking the `totalEvents` SET clause fails existing upsert tests.
- `vp check` 0, `bun run check` 0; no bare `.returning()` remains on the log insert.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
