### PR TITLE
perf(logs): bound first-page COUNT with a ceiling and report capped total (F11)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -35,7 +35,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 010 | [Test ingest rate-limit 429 wiring](010-test-ingest-rate-limit-429.md)                                        | F8      | tests            | P2       | S      | LOW     | done   |
 | 011 | [Test incidents SSE stream](011-test-incidents-sse-stream.md)                                                 | F9      | tests            | P2       | M      | LOW     | done   |
 | 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | done   |
-| 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | todo   |
+| 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | done   |
 | 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | todo   |
 | 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | todo   |
 | 016 | [Unify (app) loader ownership + DB seam](016-unify-app-loader-ownership-and-db-seam.md)                       | F13     | tech-debt        | P3       | M      | MED     | todo   |

--- a/src/lib/server/utils/capped-count.ts
+++ b/src/lib/server/utils/capped-count.ts
@@ -1,0 +1,42 @@
+import { count, type SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { PgDatabase } from "drizzle-orm/pg-core";
+import { log } from "$lib/server/db/schema";
+
+/**
+ * Maximum number of matching rows the capped count will scan.
+ * Postgres stops after this many rows, bounding the cost of the COUNT query.
+ * The UI renders "N+" when `capped` is true, signalling the real count is ≥ this value.
+ */
+export const LOG_COUNT_CEILING = 10_000;
+
+/**
+ * Run a bounded COUNT against the log table.
+ *
+ * Instead of `SELECT count(*) FROM log WHERE …` (which scans all matching rows),
+ * this issues:
+ *   SELECT count(*) FROM (SELECT 1 FROM log WHERE <whereClause> LIMIT 10000) capped
+ *
+ * Postgres stops scanning after LOG_COUNT_CEILING matching rows, keeping the
+ * query cost proportional to the ceiling rather than the full result set size.
+ *
+ * @param db          - Drizzle database client (PgDatabase or PgliteDatabase)
+ * @param whereClause - Pre-built WHERE clause (from `and(...)`)
+ * @returns `{ total, capped }` where `capped` is true when the real count ≥ LOG_COUNT_CEILING
+ */
+export async function cappedLogCount(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: PgDatabase<any, any, any>,
+  whereClause: SQL | undefined,
+): Promise<{ total: number; capped: boolean }> {
+  const cappedSubquery = db
+    .select({ one: sql<number>`1` })
+    .from(log)
+    .where(whereClause)
+    .limit(LOG_COUNT_CEILING)
+    .as("capped");
+
+  const [row] = await db.select({ c: count() }).from(cappedSubquery);
+  const total = row?.c ?? 0;
+  return { total, capped: total >= LOG_COUNT_CEILING };
+}

--- a/src/lib/server/utils/capped-count.ts
+++ b/src/lib/server/utils/capped-count.ts
@@ -1,6 +1,6 @@
 import { count, type SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
+import type { DatabaseClient } from "$lib/server/db/db";
 import { log } from "$lib/server/db/schema";
 
 /**
@@ -20,23 +20,24 @@ export const LOG_COUNT_CEILING = 10_000;
  * Postgres stops scanning after LOG_COUNT_CEILING matching rows, keeping the
  * query cost proportional to the ceiling rather than the full result set size.
  *
- * @param db          - Drizzle database client (PgDatabase or PgliteDatabase)
+ * @param db          - Drizzle database client (Postgres.js or PGlite)
  * @param whereClause - Pre-built WHERE clause (from `and(...)`)
- * @returns `{ total, capped }` where `capped` is true when the real count ≥ LOG_COUNT_CEILING
+ * @param ceiling     - Scan ceiling (defaults to LOG_COUNT_CEILING; overridable for tests)
+ * @returns `{ total, capped }` where `capped` is true when the real count ≥ ceiling
  */
 export async function cappedLogCount(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  db: PgDatabase<any, any, any>,
+  db: DatabaseClient,
   whereClause: SQL | undefined,
+  ceiling: number = LOG_COUNT_CEILING,
 ): Promise<{ total: number; capped: boolean }> {
   const cappedSubquery = db
     .select({ one: sql<number>`1` })
     .from(log)
     .where(whereClause)
-    .limit(LOG_COUNT_CEILING)
+    .limit(ceiling)
     .as("capped");
 
   const [row] = await db.select({ c: count() }).from(cappedSubquery);
   const total = row?.c ?? 0;
-  return { total, capped: total >= LOG_COUNT_CEILING };
+  return { total, capped: total >= ceiling };
 }

--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -1,8 +1,9 @@
 import { error } from "@sveltejs/kit";
-import { and, count, desc, eq, gte, inArray, lt, or, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, or, type SQL, sql } from "drizzle-orm";
 import { env } from "$lib/server/config";
 import { log, project } from "$lib/server/db/schema";
 import { requireAuth } from "$lib/server/utils/auth-guard";
+import { cappedLogCount } from "$lib/server/utils/capped-count";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
 import { buildSearchQuery } from "$lib/server/utils/search";
 import { LOG_LEVELS, type LogLevel } from "$lib/shared/types";
@@ -130,9 +131,12 @@ export const load: PageServerLoad = async (event) => {
 
   const whereClause = and(...conditions);
 
-  // Get total count
-  const [countResult] = await db.select({ count: count() }).from(log).where(whereClause);
-  const total = countResult?.count ?? 0;
+  // Skip count on cursor pages (subsequent pages); mirrors the API optimisation.
+  // On the first page use a bounded count so the query stops scanning after
+  // LOG_COUNT_CEILING rows even for expensive predicates (e.g. full-text search).
+  const pageCountResult = cursorParam ? undefined : await cappedLogCount(db, whereClause);
+  const total = pageCountResult?.total ?? 0;
+  const totalIsCapped = pageCountResult?.capped ?? false;
 
   // Fetch logs (query one extra to detect hasMore)
   const logs = await db
@@ -185,6 +189,7 @@ export const load: PageServerLoad = async (event) => {
     })),
     pagination: {
       total,
+      totalIsCapped,
       hasMore,
       limit,
       offset,

--- a/src/routes/(app)/projects/[id]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/+page.svelte
@@ -518,7 +518,7 @@ function handleKeyboardShortcut(event: KeyboardEvent) {
     <!-- Pagination Info -->
     {#if data.pagination.total > 0}
       <div class="text-xs sm:text-sm text-muted-foreground">
-        Showing {Math.min(allLogs.length, data.pagination.limit)} of {data.pagination.total} logs
+        Showing {Math.min(allLogs.length, data.pagination.limit)} of {data.pagination.totalIsCapped ? `${data.pagination.total.toLocaleString()}+` : data.pagination.total.toLocaleString()} logs
         {#if data.pagination.hasMore}
           <span class="ml-2">(more available)</span>
         {/if}

--- a/src/routes/api/projects/[id]/logs/+server.ts
+++ b/src/routes/api/projects/[id]/logs/+server.ts
@@ -1,8 +1,9 @@
 import { json } from "@sveltejs/kit";
-import { and, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, lte, or, type SQL, sql } from "drizzle-orm";
 import { getDbClient } from "$lib/server/db/db";
 import { log } from "$lib/server/db/schema";
 import { apiError } from "$lib/server/utils/api-error";
+import { cappedLogCount } from "$lib/server/utils/capped-count";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
 import { buildSearchQuery } from "$lib/server/utils/search";
@@ -147,10 +148,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
 
   const whereClause = and(...conditions);
 
-  // Skip COUNT(*) when a cursor is provided (subsequent pages); saves a DB round-trip
-  const total = cursorParam
-    ? undefined
-    : ((await db.select({ count: count() }).from(log).where(whereClause))[0]?.count ?? 0);
+  // Skip COUNT(*) when a cursor is provided (subsequent pages); saves a DB round-trip.
+  // On the first page use a bounded count (capped at LOG_COUNT_CEILING) so the query
+  // stops scanning after that many rows even for expensive predicates (e.g. full-text search).
+  const countResult = cursorParam ? undefined : await cappedLogCount(db, whereClause);
+  const total = countResult?.total;
+  const totalIsCapped = countResult?.capped ?? false;
 
   // Fetch logs with pagination (query one extra to detect hasMore)
   const logs = await db
@@ -194,6 +197,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
       timestamp: l.timestamp?.toISOString(),
     })),
     total: total ?? null,
+    total_is_capped: totalIsCapped,
     has_more: hasMore,
     nextCursor,
   });

--- a/tests/integration/utils/capped-count.integration.test.ts
+++ b/tests/integration/utils/capped-count.integration.test.ts
@@ -1,0 +1,66 @@
+import { eq } from "drizzle-orm";
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type * as schema from "$lib/server/db/schema";
+import { log } from "$lib/server/db/schema";
+import { setupTestDatabase } from "$lib/server/db/test-db";
+import { cappedLogCount, LOG_COUNT_CEILING } from "$lib/server/utils/capped-count";
+import { seedLogs, seedProject } from "../../fixtures/db";
+
+describe("cappedLogCount", () => {
+  let db: PgliteDatabase<typeof schema>;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const setup = await setupTestDatabase();
+    db = setup.db;
+    cleanup = setup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("returns the exact count and capped=false below the ceiling", async () => {
+    const project = await seedProject(db);
+    await seedLogs(db, project.id, 3);
+
+    const result = await cappedLogCount(db, eq(log.projectId, project.id));
+
+    expect(result.total).toBe(3);
+    expect(result.capped).toBe(false);
+  });
+
+  it("caps the count and sets capped=true once the ceiling is reached", async () => {
+    const project = await seedProject(db);
+    await seedLogs(db, project.id, 3);
+
+    // Use a tiny ceiling to exercise the cap without seeding LOG_COUNT_CEILING rows.
+    const result = await cappedLogCount(db, eq(log.projectId, project.id), 2);
+
+    expect(result.total).toBe(2); // LIMIT 2 inside the subquery stops the scan
+    expect(result.capped).toBe(true);
+  });
+
+  it("returns total=0, capped=false when nothing matches", async () => {
+    const project = await seedProject(db);
+    await seedLogs(db, project.id, 1);
+
+    const result = await cappedLogCount(db, eq(log.projectId, "does-not-exist"), 2);
+
+    expect(result.total).toBe(0);
+    expect(result.capped).toBe(false);
+  });
+
+  it("defaults the ceiling to LOG_COUNT_CEILING", async () => {
+    const project = await seedProject(db);
+    await seedLogs(db, project.id, 5);
+
+    // Default ceiling is 10_000, far above 5 → exact count, not capped.
+    const result = await cappedLogCount(db, eq(log.projectId, project.id));
+
+    expect(LOG_COUNT_CEILING).toBe(10_000);
+    expect(result.total).toBe(5);
+    expect(result.capped).toBe(false);
+  });
+});


### PR DESCRIPTION
## Plan 013 — Bound the first-page `COUNT(*)` on the logs query (finding F11)

On the first page of the log viewer (no cursor), both the API and the `(app)` page loader ran an exact `SELECT COUNT(*) FROM log WHERE …`. With an uncovered filter (full-text `search`, broad time range) this scans every matching row — the single most expensive read-path query, on every first load / filter change. A bounded count ("10,000+") keeps the page responsive; `has_more` already signals "is there more?" independently via the `limit + 1` overflow row.

### Changes
- **src/lib/server/utils/capped-count.ts** (new): `LOG_COUNT_CEILING = 10_000` and `cappedLogCount(db, whereClause, ceiling?)` — issues `SELECT count(*) FROM (SELECT 1 FROM log WHERE … LIMIT 10000) capped`, so **Postgres stops scanning at the ceiling** (the `LIMIT` is inside the subquery, not a JS `Math.min`). Typed with the repo's `DatabaseClient` seam.
- **api/projects/[id]/logs/+server.ts**: capped count + additive `total_is_capped` in the JSON response (cursor pages still skip the count).
- **(app)/projects/[id]/+page.server.ts**: capped count + **adds the cursor-page skip** (matching the API) + `pagination.totalIsCapped`.
- **(app)/projects/[id]/+page.svelte**: renders `N+` (e.g. "10,000+") when capped, exact count otherwise.
- **tests/integration/utils/capped-count.integration.test.ts** (new, 4 tests): exact-below-ceiling, **capped=true at a tiny ceiling**, empty→0, and default-ceiling cases.
- **plans/README.md**: plan 013 status → `done`.

### Verification
- `test:integration` 316/316 (incl. the 4 new capped-count tests; `has_more`/cursor behavior unchanged)
- `vp check` 0, `bun run check` 0, `knip` clean
- e2e via CI (change is an additive response field + display string).

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh); I applied the reviewer's two follow-ups (DatabaseClient type, capped-path test) and re-ran the full gate.
