### PR TITLE
perf(db): compute log.search with a single to_tsvector parse (F18)

### DIFF
--- a/drizzle/0010_single_parse_tsvector.sql
+++ b/drizzle/0010_single_parse_tsvector.sql
@@ -1,0 +1,43 @@
+-- Plan 014: Collapse log.search to a single to_tsvector parse
+--
+-- OPERATIONAL WARNING: This migration performs a full rewrite of the "log" table
+-- while holding an ACCESS EXCLUSIVE lock. On a large production table this can
+-- take a significant amount of time and will block all reads and writes for the
+-- duration. Run this migration during a scheduled maintenance window.
+-- If a zero-downtime path is required, consider: drop the GENERATED column and
+-- replace it with a trigger-maintained column plus a batched backfill (out of
+-- scope for this plan).
+--
+-- What changed and why:
+-- The previous expression called setweight(to_tsvector(...)) five times per row
+-- (once per source field, with A/B/C weights). The weights only mattered for
+-- ts_rank ordering in searchLogs, which is now removed (plan 005). Every live
+-- query uses @@ to_tsquery, which ignores weights. Concatenating all five
+-- fields and calling to_tsvector once produces an equivalent lexeme SET for
+-- @@ matching at roughly 1/5 the parse cost.
+--
+-- NOTE: keep this expression in sync with:
+--   (1) the generatedAlwaysAs in src/lib/server/db/schema.ts
+--   (2) the log_search_trigger() in src/lib/server/db/test-db.ts
+
+-- Dropping the column also drops the idx_log_search GIN index automatically.
+ALTER TABLE "log" DROP COLUMN "search";
+--> statement-breakpoint
+
+-- Recreate with the single-parse expression. concat_ws skips NULL arguments,
+-- so COALESCE per field is unnecessary.
+ALTER TABLE "log" ADD COLUMN "search" "tsvector" GENERATED ALWAYS AS (
+  to_tsvector('english',
+    concat_ws(' ',
+      "message",
+      "body"::text,
+      "metadata"::text,
+      "resource_attributes"::text,
+      "scope_attributes"::text
+    )
+  )
+) STORED;
+--> statement-breakpoint
+
+-- Recreate the GIN index for @@ queries.
+CREATE INDEX "idx_log_search" ON "log" USING gin ("search");

--- a/drizzle/0010_single_parse_tsvector.sql
+++ b/drizzle/0010_single_parse_tsvector.sql
@@ -24,17 +24,16 @@
 ALTER TABLE "log" DROP COLUMN "search";
 --> statement-breakpoint
 
--- Recreate with the single-parse expression. concat_ws skips NULL arguments,
--- so COALESCE per field is unnecessary.
+-- Recreate with the single-parse expression. Uses IMMUTABLE || + COALESCE
+-- instead of concat_ws (which is only STABLE) so that Postgres accepts the
+-- expression in a STORED generated column (requires IMMUTABLE).
 ALTER TABLE "log" ADD COLUMN "search" "tsvector" GENERATED ALWAYS AS (
   to_tsvector('english',
-    concat_ws(' ',
-      "message",
-      "body"::text,
-      "metadata"::text,
-      "resource_attributes"::text,
-      "scope_attributes"::text
-    )
+    COALESCE("message", '') || ' ' ||
+    COALESCE("body"::text, '') || ' ' ||
+    COALESCE("metadata"::text, '') || ' ' ||
+    COALESCE("resource_attributes"::text, '') || ' ' ||
+    COALESCE("scope_attributes"::text, '')
   )
 ) STORED;
 --> statement-breakpoint

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,781 @@
+{
+  "id": "34c126d2-d7cb-4da2-8d87-e8d93d5d5102",
+  "prevId": "e74e23ff-4498-4c73-96b7-6d72d767635e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log": {
+      "name": "log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_unix_nano": {
+          "name": "time_unix_nano",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_time_unix_nano": {
+          "name": "observed_time_unix_nano",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity_number": {
+          "name": "severity_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity_text": {
+          "name": "severity_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_attributes_count": {
+          "name": "dropped_attributes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_attributes": {
+          "name": "resource_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_dropped_attributes_count": {
+          "name": "resource_dropped_attributes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_schema_url": {
+          "name": "resource_schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_name": {
+          "name": "scope_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_version": {
+          "name": "scope_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_attributes": {
+          "name": "scope_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_dropped_attributes_count": {
+          "name": "scope_dropped_attributes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_schema_url": {
+          "name": "scope_schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english',\n        concat_ws(' ',\n          \"log\".\"message\",\n          \"log\".\"body\"::text,\n          \"log\".\"metadata\"::text,\n          \"log\".\"resource_attributes\"::text,\n          \"log\".\"scope_attributes\"::text\n        ))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_log_project_id": {
+          "name": "idx_log_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_log_timestamp": {
+          "name": "idx_log_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_log_level": {
+          "name": "idx_log_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_log_project_timestamp": {
+          "name": "idx_log_project_timestamp",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_log_search": {
+          "name": "idx_log_search",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_project_id_project_id_fk": {
+          "name": "log_project_id_project_id_fk",
+          "tableFrom": "log",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_api_key": {
+          "name": "idx_project_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_owner_id": {
+          "name": "idx_project_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_owner_id_user_id_fk": {
+          "name": "project_owner_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_name_unique": {
+          "name": "project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "project_api_key_unique": {
+          "name": "project_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": ["debug", "info", "warn", "error", "fatal"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -303,7 +303,7 @@
           "primaryKey": false,
           "notNull": false,
           "generated": {
-            "as": "to_tsvector('english',\n        concat_ws(' ',\n          \"log\".\"message\",\n          \"log\".\"body\"::text,\n          \"log\".\"metadata\"::text,\n          \"log\".\"resource_attributes\"::text,\n          \"log\".\"scope_attributes\"::text\n        ))",
+            "as": "to_tsvector('english',\n        COALESCE(\"log\".\"message\", '') || ' ' ||\n        COALESCE(\"log\".\"body\"::text, '') || ' ' ||\n        COALESCE(\"log\".\"metadata\"::text, '') || ' ' ||\n        COALESCE(\"log\".\"resource_attributes\"::text, '') || ' ' ||\n        COALESCE(\"log\".\"scope_attributes\"::text, ''))",
             "type": "stored"
           }
         }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780876800000,
       "tag": "0009_hash_only_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1781654400000,
+      "tag": "0010_single_parse_tsvector",
+      "breakpoints": true
     }
   ]
 }

--- a/plans/README.md
+++ b/plans/README.md
@@ -36,7 +36,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 011 | [Test incidents SSE stream](011-test-incidents-sse-stream.md)                                                 | F9      | tests            | P2       | M      | LOW     | done   |
 | 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | done   |
 | 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | done   |
-| 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | todo   |
+| 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | done   |
 | 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | todo   |
 | 016 | [Unify (app) loader ownership + DB seam](016-unify-app-loader-ownership-and-db-seam.md)                       | F13     | tech-debt        | P3       | M      | MED     | todo   |
 | 017 | [SPIKE: incident alerting webhooks](017-spike-incident-alerting-webhooks.md)                                  | D1      | direction        | P2       | L      | MED     | todo   |

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -126,13 +126,11 @@ export const log = pgTable(
     search: tsvector("search").generatedAlwaysAs(
       (): SQL =>
         sql`to_tsvector('english',
-        concat_ws(' ',
-          ${log.message},
-          ${log.body}::text,
-          ${log.metadata}::text,
-          ${log.resourceAttributes}::text,
-          ${log.scopeAttributes}::text
-        ))`,
+        COALESCE(${log.message}, '') || ' ' ||
+        COALESCE(${log.body}::text, '') || ' ' ||
+        COALESCE(${log.metadata}::text, '') || ' ' ||
+        COALESCE(${log.resourceAttributes}::text, '') || ' ' ||
+        COALESCE(${log.scopeAttributes}::text, ''))`,
     ),
   },
   (table) => [

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -121,13 +121,18 @@ export const log = pgTable(
     userId: text("user_id"),
     ipAddress: text("ip_address"),
     timestamp: timestamp("timestamp", { withTimezone: true }).defaultNow().notNull(),
+    // NOTE: keep this expression in sync with the PGlite trigger in test-db.ts
+    // and any new migration that recreates this column (see drizzle/0010_*.sql).
     search: tsvector("search").generatedAlwaysAs(
       (): SQL =>
-        sql`setweight(to_tsvector('english', ${log.message}), 'A') ||
-        setweight(to_tsvector('english', COALESCE(${log.body}::text, '')), 'B') ||
-        setweight(to_tsvector('english', COALESCE(${log.metadata}::text, '')), 'B') ||
-        setweight(to_tsvector('english', COALESCE(${log.resourceAttributes}::text, '')), 'C') ||
-        setweight(to_tsvector('english', COALESCE(${log.scopeAttributes}::text, '')), 'C')`,
+        sql`to_tsvector('english',
+        concat_ws(' ',
+          ${log.message},
+          ${log.body}::text,
+          ${log.metadata}::text,
+          ${log.resourceAttributes}::text,
+          ${log.scopeAttributes}::text
+        ))`,
     ),
   },
   (table) => [

--- a/src/lib/server/db/test-db.ts
+++ b/src/lib/server/db/test-db.ts
@@ -289,14 +289,14 @@ async function createTriggers(db: PgliteDatabase<typeof schema>): Promise<void> 
       BEGIN
         -- NOTE: keep this expression in sync with the generatedAlwaysAs in schema.ts
         -- and the migration that recreates the column (drizzle/0010_*.sql).
+        -- Uses || + COALESCE (not concat_ws) to match the IMMUTABLE expression
+        -- required by the Postgres STORED generated column.
         NEW.search := to_tsvector('english',
-          concat_ws(' ',
-            NEW.message,
-            NEW.body::text,
-            NEW.metadata::text,
-            NEW.resource_attributes::text,
-            NEW.scope_attributes::text
-          ));
+          COALESCE(NEW.message, '') || ' ' ||
+          COALESCE(NEW.body::text, '') || ' ' ||
+          COALESCE(NEW.metadata::text, '') || ' ' ||
+          COALESCE(NEW.resource_attributes::text, '') || ' ' ||
+          COALESCE(NEW.scope_attributes::text, ''));
         RETURN NEW;
       END
       $$ LANGUAGE plpgsql;

--- a/src/lib/server/db/test-db.ts
+++ b/src/lib/server/db/test-db.ts
@@ -287,11 +287,16 @@ async function createTriggers(db: PgliteDatabase<typeof schema>): Promise<void> 
       sql.raw(`
       CREATE OR REPLACE FUNCTION log_search_trigger() RETURNS trigger AS $$
       BEGIN
-        NEW.search := setweight(to_tsvector('english', NEW.message), 'A') ||
-                      setweight(to_tsvector('english', COALESCE(NEW.body::text, '')), 'B') ||
-                      setweight(to_tsvector('english', COALESCE(NEW.metadata::text, '')), 'B') ||
-                      setweight(to_tsvector('english', COALESCE(NEW.resource_attributes::text, '')), 'C') ||
-                      setweight(to_tsvector('english', COALESCE(NEW.scope_attributes::text, '')), 'C');
+        -- NOTE: keep this expression in sync with the generatedAlwaysAs in schema.ts
+        -- and the migration that recreates the column (drizzle/0010_*.sql).
+        NEW.search := to_tsvector('english',
+          concat_ws(' ',
+            NEW.message,
+            NEW.body::text,
+            NEW.metadata::text,
+            NEW.resource_attributes::text,
+            NEW.scope_attributes::text
+          ));
         RETURN NEW;
       END
       $$ LANGUAGE plpgsql;

--- a/tests/integration/api/projects/logs/logs-query.integration.test.ts
+++ b/tests/integration/api/projects/logs/logs-query.integration.test.ts
@@ -461,6 +461,96 @@ describe("GET /api/projects/[id]/logs", () => {
       expect(body.logs[0]!.metadata).toHaveProperty("service", "payment-gateway");
     });
 
+    // Plan 014: verify the single-parse to_tsvector still indexes all five source fields.
+    // Each test seeds a log whose searchable term appears ONLY in one non-message field,
+    // confirming the concat_ws concatenation covers that field.
+    // The sentinel log gets a unique message prefix ("bodyonly-", "resonly-", "scopeonly-")
+    // so we can distinguish it from other logs returned by the search via the message field
+    // (body/resourceAttributes/scopeAttributes are not projected by the logs API).
+    it("performs full-text search on body (single-parse tsvector covers body field)", async () => {
+      const testProject = await seedProject(db, { ownerId: userId });
+
+      // "glacier" only appears in body — message is generic
+      await seedLog(db, testProject.id, {
+        message: "bodyonly-sentinel log entry",
+        body: { text: "glacier mountain alpine" },
+      });
+      await seedLog(db, testProject.id, {
+        message: "unrelated log without body term",
+        body: null,
+      });
+
+      const request = new Request(
+        `http://localhost/api/projects/${testProject.id}/logs?search=glacier`,
+        { method: "GET" },
+      );
+
+      const event = createRequestEvent(request, db, { id: testProject.id }, authenticatedLocals);
+      const response = await GET(event as never);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+
+      expect(body.logs).toHaveLength(1);
+      expect(body.logs[0]!.message).toBe("bodyonly-sentinel log entry");
+    });
+
+    it("performs full-text search on resource_attributes (single-parse tsvector covers resource_attributes field)", async () => {
+      const testProject = await seedProject(db, { ownerId: userId });
+
+      // "archipelago" only appears in resource_attributes
+      await seedLog(db, testProject.id, {
+        message: "resonly-sentinel log entry",
+        resourceAttributes: { "service.name": "archipelago-service" },
+      });
+      await seedLog(db, testProject.id, {
+        message: "unrelated log without resource term",
+        resourceAttributes: null,
+      });
+
+      const request = new Request(
+        `http://localhost/api/projects/${testProject.id}/logs?search=archipelago`,
+        { method: "GET" },
+      );
+
+      const event = createRequestEvent(request, db, { id: testProject.id }, authenticatedLocals);
+      const response = await GET(event as never);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+
+      expect(body.logs).toHaveLength(1);
+      expect(body.logs[0]!.message).toBe("resonly-sentinel log entry");
+    });
+
+    it("performs full-text search on scope_attributes (single-parse tsvector covers scope_attributes field)", async () => {
+      const testProject = await seedProject(db, { ownerId: userId });
+
+      // "phosphorescent" only appears in scope_attributes
+      await seedLog(db, testProject.id, {
+        message: "scopeonly-sentinel log entry",
+        scopeAttributes: { library: "phosphorescent-sdk" },
+      });
+      await seedLog(db, testProject.id, {
+        message: "unrelated log without scope term",
+        scopeAttributes: null,
+      });
+
+      const request = new Request(
+        `http://localhost/api/projects/${testProject.id}/logs?search=phosphorescent`,
+        { method: "GET" },
+      );
+
+      const event = createRequestEvent(request, db, { id: testProject.id }, authenticatedLocals);
+      const response = await GET(event as never);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+
+      expect(body.logs).toHaveLength(1);
+      expect(body.logs[0]!.message).toBe("scopeonly-sentinel log entry");
+    });
+
     it("handles multi-word search query", async () => {
       const testProject = await seedProject(db, { ownerId: userId });
 

--- a/tests/integration/api/projects/logs/logs-query.integration.test.ts
+++ b/tests/integration/api/projects/logs/logs-query.integration.test.ts
@@ -463,7 +463,7 @@ describe("GET /api/projects/[id]/logs", () => {
 
     // Plan 014: verify the single-parse to_tsvector still indexes all five source fields.
     // Each test seeds a log whose searchable term appears ONLY in one non-message field,
-    // confirming the concat_ws concatenation covers that field.
+    // confirming the COALESCE/|| concatenation covers that field.
     // The sentinel log gets a unique message prefix ("bodyonly-", "resonly-", "scopeonly-")
     // so we can distinguish it from other logs returned by the search via the message field
     // (body/resourceAttributes/scopeAttributes are not projected by the logs API).


### PR DESCRIPTION
## Plan 014 — Collapse the 5-call `search` tsvector into a single `to_tsvector` parse (finding F18)

`log.search` was a STORED generated `tsvector` computed on **every insert** as five `setweight(to_tsvector('english', …))` calls (message/body/metadata/resource/scope). The per-field A/B/C weights only ever mattered for `ts_rank` in `searchLogs` — dead code removed in plan 005. Every live query uses `@@`, which ignores weights. Concatenating the five fields and parsing **once** yields an equivalent lexeme set for `@@` at ~1/5 the write-time parse cost.

### Changes (three synchronized definitions kept in lockstep)
- **schema.ts**: `generatedAlwaysAs` → single `to_tsvector('english', COALESCE(message,'')||' '||COALESCE(body::text,'')||…)`.
- **test-db.ts**: PGlite `log_search_trigger()` updated to the identical expression.
- **drizzle/0010_single_parse_tsvector.sql** (new, hand-written): `DROP COLUMN search` → `ADD COLUMN … GENERATED ALWAYS AS (…) STORED` → recreate `idx_log_search` GIN index. Includes an **operational warning** that this full-table rewrite holds an `ACCESS EXCLUSIVE` lock (run in a maintenance window). Meta snapshot + journal updated; no historical migration touched.
- **logs-query.integration.test.ts**: 3 new tests proving `@@` still matches terms found ONLY in body / resource_attributes / scope_attributes (mutation-proven non-vacuous).
- **plans/README.md**: plan 014 status → `done`.

### Critical deviation from the plan (correct)
The plan suggested `concat_ws(' ', …)`, but **`concat_ws` is only STABLE** while a STORED generated column requires an **IMMUTABLE** expression — `concat_ws` would have failed CI's `test-migrations` job with *"generation expression is not immutable"*. Switched to `COALESCE + ||` (all IMMUTABLE). The plan explicitly allowed keeping COALESCE.

### Verification (including real Postgres 18, beyond CI)
- `test:integration` 319/319 (incl. 3 new per-field tests); `test:unit` 338; `vp check` 0, `bun run check` 0, `knip` clean.
- **Applied all migrations 0000→0010 to a fresh `postgres:18-alpine`** (replicating CI's `test-migrations`): `migrations applied successfully`. Confirmed `search` is a generated column, `idx_log_search` GIN index exists, and `@@` matches a term living **only in `scope_attributes`** (proves all 5 fields indexed), matches message terms, and returns 0 for absent terms.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — 1 fix round (the immutability fix).
