### PR TITLE
refactor: dedup getTimeRangeStart and parseLevelFilter (RT-10) (F12)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -37,7 +37,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 012 | [Batch incident upsert + narrow returning](012-batch-incident-upsert-and-narrow-returning.md)                 | F3+F7   | perf             | P2       | M      | MED     | done   |
 | 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | done   |
 | 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | done   |
-| 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | todo   |
+| 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | done   |
 | 016 | [Unify (app) loader ownership + DB seam](016-unify-app-loader-ownership-and-db-seam.md)                       | F13     | tech-debt        | P3       | M      | MED     | todo   |
 | 017 | [SPIKE: incident alerting webhooks](017-spike-incident-alerting-webhooks.md)                                  | D1      | direction        | P2       | L      | MED     | todo   |
 | 018 | [SPIKE: read/query API + SDKs](018-spike-read-query-api-and-sdks.md)                                          | D2      | direction        | P3       | L      | MED     | todo   |

--- a/src/lib/components/export-button.svelte
+++ b/src/lib/components/export-button.svelte
@@ -4,6 +4,7 @@ import type { TimeRange } from '$lib/components/time-range-picker.svelte';
 import { Button } from '$lib/components/ui/button';
 import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 import type { LogLevel } from '$lib/shared/types';
+import { getTimeRangeStart } from '$lib/utils/format';
 import { toastError } from '$lib/utils/toast';
 
 interface Props {
@@ -14,27 +15,6 @@ interface Props {
 }
 
 const { projectId, level, search, range }: Props = $props();
-
-/**
- * Get time range start date based on range parameter
- */
-function getTimeRangeStart(timeRange: TimeRange | undefined): Date | null {
-  if (!timeRange) return null;
-
-  const now = Date.now();
-  switch (timeRange) {
-    case '15m':
-      return new Date(now - 15 * 60 * 1000);
-    case '1h':
-      return new Date(now - 60 * 60 * 1000);
-    case '24h':
-      return new Date(now - 24 * 60 * 60 * 1000);
-    case '7d':
-      return new Date(now - 7 * 24 * 60 * 60 * 1000);
-    default:
-      return null;
-  }
-}
 
 /**
  * Build export URL with current filters
@@ -52,7 +32,7 @@ function buildExportUrl(format: 'csv' | 'json'): string {
   }
 
   // Convert time range to from/to timestamps
-  const fromDate = getTimeRangeStart(range);
+  const fromDate = range ? getTimeRangeStart(range) : null;
   if (fromDate) {
     params.set('from', fromDate.toISOString());
   }

--- a/src/lib/shared/schemas/log-level.unit.test.ts
+++ b/src/lib/shared/schemas/log-level.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { LOG_LEVELS, logLevelSchema } from "./log";
+import { LOG_LEVELS, logLevelSchema, parseLevelFilter } from "./log";
 
 describe("logLevelSchema", () => {
   it("accepts all valid log levels", () => {
@@ -12,5 +12,44 @@ describe("logLevelSchema", () => {
   it("rejects invalid log level", () => {
     const result = logLevelSchema.safeParse("invalid");
     expect(result.success).toBe(false);
+  });
+});
+
+describe("parseLevelFilter", () => {
+  it("returns null for null input", () => {
+    expect(parseLevelFilter(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseLevelFilter("")).toBeNull();
+  });
+
+  it("returns null when all values are invalid", () => {
+    expect(parseLevelFilter("critical,trace")).toBeNull();
+  });
+
+  it("returns a single valid level", () => {
+    expect(parseLevelFilter("error")).toEqual(["error"]);
+  });
+
+  it("parses a comma-separated list of valid levels", () => {
+    expect(parseLevelFilter("error,fatal")).toEqual(["error", "fatal"]);
+  });
+
+  it("trims whitespace around level names", () => {
+    expect(parseLevelFilter(" warn , info ")).toEqual(["warn", "info"]);
+  });
+
+  it("lowercases level names", () => {
+    expect(parseLevelFilter("ERROR,WARN")).toEqual(["error", "warn"]);
+  });
+
+  it("filters out invalid levels from a mixed list", () => {
+    expect(parseLevelFilter("error,critical,fatal")).toEqual(["error", "fatal"]);
+  });
+
+  it("accepts all valid log levels", () => {
+    const all = LOG_LEVELS.join(",");
+    expect(parseLevelFilter(all)).toEqual([...LOG_LEVELS]);
   });
 });

--- a/src/lib/shared/schemas/log.ts
+++ b/src/lib/shared/schemas/log.ts
@@ -14,3 +14,20 @@ export const logLevelSchema = z.enum(LOG_LEVELS);
  * Log level type
  */
 export type LogLevel = z.infer<typeof logLevelSchema>;
+
+/**
+ * Parse and validate level filter from a query-string parameter.
+ * Accepts a comma-separated list of level names (case-insensitive).
+ * Returns an array of valid LogLevel values, or null if the param is
+ * absent, empty, or contains no recognised values.
+ */
+export function parseLevelFilter(levelParam: string | null): LogLevel[] | null {
+  if (!levelParam) return null;
+
+  const levels = levelParam
+    .split(",")
+    .map((l) => l.trim().toLowerCase())
+    .filter((l): l is LogLevel => LOG_LEVELS.includes(l as LogLevel));
+
+  return levels.length > 0 ? levels : null;
+}

--- a/src/lib/utils/time-range.ts
+++ b/src/lib/utils/time-range.ts
@@ -8,3 +8,13 @@ export const TIME_RANGE_LABELS: Record<TimeRange, string> = {
   "24h": "Last 24 hours",
   "7d": "Last 7 days",
 };
+
+/**
+ * Parse and validate a time-range query parameter.
+ * Returns the narrowed TimeRange value if valid, or null for absent/unknown input.
+ * This reproduces the `string | null → TimeRange | null` semantics needed by
+ * page loaders that must handle raw query params before calling getTimeRangeStart.
+ */
+export function parseTimeRange(param: string | null): TimeRange | null {
+  return param && (TIME_RANGES as readonly string[]).includes(param) ? (param as TimeRange) : null;
+}

--- a/src/lib/utils/time-range.unit.test.ts
+++ b/src/lib/utils/time-range.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+import { TIME_RANGES, parseTimeRange } from "./time-range";
+
+describe("parseTimeRange", () => {
+  it("returns null for null input", () => {
+    expect(parseTimeRange(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseTimeRange("")).toBeNull();
+  });
+
+  it("returns null for unknown range string", () => {
+    expect(parseTimeRange("99z")).toBeNull();
+    expect(parseTimeRange("2h")).toBeNull();
+    expect(parseTimeRange("30m")).toBeNull();
+  });
+
+  it.each(TIME_RANGES)("returns %s for valid range input %s", (range) => {
+    expect(parseTimeRange(range)).toBe(range);
+  });
+
+  it("is case-sensitive (uppercase variants are invalid)", () => {
+    expect(parseTimeRange("15M")).toBeNull();
+    expect(parseTimeRange("1H")).toBeNull();
+    expect(parseTimeRange("24H")).toBeNull();
+    expect(parseTimeRange("7D")).toBeNull();
+  });
+});

--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -6,7 +6,9 @@ import { requireAuth } from "$lib/server/utils/auth-guard";
 import { cappedLogCount } from "$lib/server/utils/capped-count";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
 import { buildSearchQuery } from "$lib/server/utils/search";
-import { LOG_LEVELS, type LogLevel } from "$lib/shared/types";
+import { parseLevelFilter } from "$lib/shared/schemas/log";
+import { getTimeRangeStart } from "$lib/utils/format";
+import { parseTimeRange } from "$lib/utils/time-range";
 import type { PageServerLoad } from "./$types";
 
 // Constants for pagination
@@ -19,37 +21,6 @@ const MAX_LIMIT = 500;
  */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
-}
-
-// TODO(RT-10): deduplicate with api/projects/[id]/logs/+server.ts parseLevelFilter
-function parseLevelFilter(levelParam: string | null): LogLevel[] | null {
-  if (!levelParam) return null;
-
-  const levels = levelParam
-    .split(",")
-    .map((l) => l.trim().toLowerCase())
-    .filter((l): l is LogLevel => LOG_LEVELS.includes(l as LogLevel));
-
-  return levels.length > 0 ? levels : null;
-}
-
-// TODO(RT-10): deduplicate with $lib/utils/format getTimeRangeStart
-function getTimeRangeStart(range: string | null): Date | null {
-  if (!range) return null;
-
-  const now = Date.now();
-  switch (range) {
-    case "15m":
-      return new Date(now - 15 * 60 * 1000);
-    case "1h":
-      return new Date(now - 60 * 60 * 1000);
-    case "24h":
-      return new Date(now - 24 * 60 * 60 * 1000);
-    case "7d":
-      return new Date(now - 7 * 24 * 60 * 60 * 1000);
-    default:
-      return null;
-  }
 }
 
 export const load: PageServerLoad = async (event) => {
@@ -88,7 +59,8 @@ export const load: PageServerLoad = async (event) => {
 
   // Parse filters
   const levels = parseLevelFilter(levelParam);
-  const fromDate = getTimeRangeStart(rangeParam);
+  const range = parseTimeRange(rangeParam);
+  const fromDate = range ? getTimeRangeStart(range) : null;
 
   // Build WHERE conditions
   const conditions: SQL[] = [eq(log.projectId, projectId)];

--- a/src/routes/(app)/projects/[id]/stats/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/stats/+page.server.ts
@@ -2,26 +2,9 @@ import { error } from "@sveltejs/kit";
 import { and, count, eq, gte, type SQL } from "drizzle-orm";
 import { log, project } from "$lib/server/db/schema";
 import { requireAuth } from "$lib/server/utils/auth-guard";
+import { getTimeRangeStart } from "$lib/utils/format";
+import { parseTimeRange } from "$lib/utils/time-range";
 import type { PageServerLoad } from "./$types";
-
-// TODO(RT-10): deduplicate with $lib/utils/format getTimeRangeStart
-function getTimeRangeStart(range: string | null): Date | null {
-  if (!range) return null;
-
-  const now = Date.now();
-  switch (range) {
-    case "15m":
-      return new Date(now - 15 * 60 * 1000);
-    case "1h":
-      return new Date(now - 60 * 60 * 1000);
-    case "24h":
-      return new Date(now - 24 * 60 * 60 * 1000);
-    case "7d":
-      return new Date(now - 7 * 24 * 60 * 60 * 1000);
-    default:
-      return null;
-  }
-}
 
 export const load: PageServerLoad = async (event) => {
   // Require session authentication
@@ -45,7 +28,8 @@ export const load: PageServerLoad = async (event) => {
   const rangeParam = url.searchParams.get("range") || "24h";
 
   // Calculate time range
-  const fromDate = getTimeRangeStart(rangeParam);
+  const range = parseTimeRange(rangeParam);
+  const fromDate = range ? getTimeRangeStart(range) : null;
 
   // Build WHERE conditions
   const conditions: SQL[] = [eq(log.projectId, projectId)];

--- a/src/routes/api/projects/[id]/logs/+server.ts
+++ b/src/routes/api/projects/[id]/logs/+server.ts
@@ -7,7 +7,7 @@ import { cappedLogCount } from "$lib/server/utils/capped-count";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
 import { buildSearchQuery } from "$lib/server/utils/search";
-import { LOG_LEVELS, type LogLevel } from "$lib/shared/types";
+import { parseLevelFilter } from "$lib/shared/schemas/log";
 import type { RequestEvent } from "./$types";
 
 // Constants for pagination limits
@@ -20,21 +20,6 @@ const MAX_LIMIT = 500;
  */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
-}
-
-/**
- * Parse and validate level filter from query string
- * Returns array of valid log levels or null if no filter
- */
-function parseLevelFilter(levelParam: string | null): LogLevel[] | null {
-  if (!levelParam) return null;
-
-  const levels = levelParam
-    .split(",")
-    .map((l) => l.trim().toLowerCase())
-    .filter((l): l is LogLevel => LOG_LEVELS.includes(l as LogLevel));
-
-  return levels.length > 0 ? levels : null;
 }
 
 /**

--- a/src/routes/api/projects/[id]/logs/export/+server.ts
+++ b/src/routes/api/projects/[id]/logs/export/+server.ts
@@ -6,7 +6,7 @@ import { apiError } from "$lib/server/utils/api-error";
 import { escapeCSVField } from "$lib/server/utils/csv-serializer";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
 import { buildSearchQuery } from "$lib/server/utils/search";
-import { LOG_LEVELS, type LogLevel } from "$lib/shared/types";
+import { parseLevelFilter } from "$lib/shared/schemas/log";
 import type { ExportFormat } from "$lib/types/export";
 import type { RequestEvent } from "./$types";
 
@@ -24,18 +24,6 @@ const CSV_HEADERS = [
   "userId",
   "ipAddress",
 ] as const;
-
-// TODO: deduplicate with logs/+server.ts parseLevelFilter (RT-10)
-function parseLevelFilter(levelParam: string | null): LogLevel[] | null {
-  if (!levelParam) return null;
-
-  const levels = levelParam
-    .split(",")
-    .map((l) => l.trim().toLowerCase())
-    .filter((l): l is LogLevel => LOG_LEVELS.includes(l as LogLevel));
-
-  return levels.length > 0 ? levels : null;
-}
 
 /**
  * Validate export format parameter


### PR DESCRIPTION
## Plan 015 — Deduplicate `getTimeRangeStart` and `parseLevelFilter` (the `TODO(RT-10)` cluster) (finding F12)

Two small parsing helpers were copy-pasted across the logs/stats/incidents read paths and had **drifted** — the dangerous kind of duplication the repo's own `TODO(RT-10)` comments flagged.

### Changes
- **parseLevelFilter** (was 3 byte-identical copies): extracted to `src/lib/shared/schemas/log.ts`; all 3 sites now import it.
- **getTimeRangeStart**: kept the strict canonical (`format.ts`) untouched; added `parseTimeRange(param)` to `time-range.ts`; the 2 drifted page-loader copies now do `const r = parseTimeRange(p); const from = r ? getTimeRangeStart(r) : null;` (reproduces the old `Date|null` semantics exactly). The `export-button.svelte` client copy also removed (Step 4 — verified `format.ts` is pure date math, no client-bundle bloat).
- The 4 *correct* canonical importers (incidents/timeline/timeseries) are **unchanged**.
- 2 new unit-test files for `parseTimeRange` and `parseLevelFilter`.
- All `TODO(RT-10)` markers removed.
- **plans/README.md**: plan 015 status → `done`.

### Verification
- `git grep "function parseLevelFilter"` → exactly 1; `"function getTimeRangeStart"` → exactly 1; `TODO(RT-10)` → none.
- Behavior parity confirmed for valid/null/invalid/default inputs at each migrated call site (incl. the stats loader's `"24h"` default).
- `bun run test` **1026/1026**; `test:integration -- logs/stats/incidents` green; `vp check` 0, `bun run check` 0, `knip` clean.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
