### PR TITLE
refactor(app): route page loaders through requireProjectOwnership and getDbClient seams (F13)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -38,7 +38,7 @@ Legend: **P1** critical · **P2** high · **P3** medium. Effort **S**<½day · *
 | 013 | [Cap unbounded log COUNT(\*)](013-cap-unbounded-log-count.md)                                                 | F11     | perf             | P3       | M      | MED     | done   |
 | 014 | [Collapse tsvector to single parse](014-collapse-tsvector-to-single-parse.md)                                 | F18     | perf             | P3       | L      | HIGH    | done   |
 | 015 | [Dedup getTimeRangeStart + parseLevelFilter](015-dedup-timerange-and-levelfilter.md)                          | F12     | tech-debt        | P3       | M      | MED     | done   |
-| 016 | [Unify (app) loader ownership + DB seam](016-unify-app-loader-ownership-and-db-seam.md)                       | F13     | tech-debt        | P3       | M      | MED     | todo   |
+| 016 | [Unify (app) loader ownership + DB seam](016-unify-app-loader-ownership-and-db-seam.md)                       | F13     | tech-debt        | P3       | M      | MED     | done   |
 | 017 | [SPIKE: incident alerting webhooks](017-spike-incident-alerting-webhooks.md)                                  | D1      | direction        | P2       | L      | MED     | todo   |
 | 018 | [SPIKE: read/query API + SDKs](018-spike-read-query-api-and-sdks.md)                                          | D2      | direction        | P3       | L      | MED     | todo   |
 | 019 | [SPIKE: incident lifecycle](019-spike-incident-lifecycle.md)                                                  | D3      | direction        | P3       | L      | HIGH    | todo   |

--- a/src/lib/server/utils/project-guard.ts
+++ b/src/lib/server/utils/project-guard.ts
@@ -1,4 +1,4 @@
-import { json, type RequestEvent } from "@sveltejs/kit";
+import { error, json, type RequestEvent } from "@sveltejs/kit";
 import { and, eq } from "drizzle-orm";
 import { getDbClient } from "$lib/server/db/db";
 import { type Project, project } from "$lib/server/db/schema";
@@ -12,11 +12,34 @@ export interface AuthorizedProject extends AuthenticatedSession {
 }
 
 /**
- * Requires project ownership for protected routes
+ * Shared ownership query used by both API and page-loader helpers.
+ * Performs auth + DB lookup and returns raw results so each wrapper
+ * can decide how to signal failure (JSON 404 vs SvelteKit error page).
+ */
+async function findOwnedProject(
+  event: RequestEvent,
+  projectId: string,
+): Promise<{
+  projectData: Project | undefined;
+  user: AuthenticatedSession["user"];
+  session: AuthenticatedSession["session"];
+}> {
+  const { user, session } = await requireAuth(event);
+  const db = await getDbClient(event.locals);
+  const [projectData] = await db
+    .select()
+    .from(project)
+    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
+  return { projectData, user, session };
+}
+
+/**
+ * Requires project ownership for API routes.
  *
  * Checks if the authenticated user owns the specified project.
  * If not authenticated, throws a redirect to /login.
- * If project not found or not owned by user, returns a 404 JSON response.
+ * If project not found or not owned by user, returns a 404 JSON response
+ * (correct for API/fetch clients).
  *
  * @param event - SvelteKit RequestEvent from load function or action
  * @param projectId - The project ID to check ownership for
@@ -36,20 +59,37 @@ export async function requireProjectOwnership(
   event: RequestEvent,
   projectId: string,
 ): Promise<AuthorizedProject | Response> {
-  // First, require authentication
-  const { user, session } = await requireAuth(event);
-
-  const db = await getDbClient(event.locals);
-
-  // Query project with ownership check
-  const [projectData] = await db
-    .select()
-    .from(project)
-    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
+  const { projectData, user, session } = await findOwnedProject(event, projectId);
 
   if (!projectData) {
     // Return 404 to hide existence from non-owners
     return json({ error: "not_found", message: "Project not found" }, { status: 404 });
+  }
+
+  return { project: projectData, user, session };
+}
+
+/**
+ * Requires project ownership for page loaders.
+ *
+ * Identical ownership check to `requireProjectOwnership`, but signals
+ * failure by throwing a SvelteKit `error(404, ...)` so the error PAGE
+ * is rendered (not a JSON blob). Use this in `+page.server.ts` loaders.
+ *
+ * @param event - SvelteKit RequestEvent from load function or action
+ * @param projectId - The project ID to check ownership for
+ * @returns Promise resolving to { project, user, session }
+ * @throws SvelteKit 404 error page if project not found or not owned by user
+ * @throws Redirect to /login if not authenticated
+ */
+export async function requireProjectOwnershipPage(
+  event: RequestEvent,
+  projectId: string,
+): Promise<AuthorizedProject> {
+  const { projectData, user, session } = await findOwnedProject(event, projectId);
+
+  if (!projectData) {
+    throw error(404, { message: "Project not found" });
   }
 
   return { project: projectData, user, session };

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -1,5 +1,5 @@
 import { count, desc, eq, max } from "drizzle-orm";
-import { db } from "$lib/server/db";
+import { getDbClient } from "$lib/server/db/db";
 import { log, project } from "$lib/server/db/schema";
 import { requireAuth } from "$lib/server/utils/auth-guard";
 import type { PageServerLoad } from "./$types";
@@ -11,6 +11,7 @@ import type { PageServerLoad } from "./$types";
 export const load: PageServerLoad = async (event) => {
   // Require session authentication
   const { user } = await requireAuth(event);
+  const db = await getDbClient(event.locals);
 
   // Query only projects owned by the current user
   const projects = await db

--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -1,10 +1,10 @@
-import { error } from "@sveltejs/kit";
 import { and, desc, eq, gte, inArray, lt, or, type SQL, sql } from "drizzle-orm";
 import { env } from "$lib/server/config";
-import { log, project } from "$lib/server/db/schema";
-import { requireAuth } from "$lib/server/utils/auth-guard";
+import { getDbClient } from "$lib/server/db/db";
+import { log } from "$lib/server/db/schema";
 import { cappedLogCount } from "$lib/server/utils/capped-count";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
+import { requireProjectOwnershipPage } from "$lib/server/utils/project-guard";
 import { buildSearchQuery } from "$lib/server/utils/search";
 import { parseLevelFilter } from "$lib/shared/schemas/log";
 import { getTimeRangeStart } from "$lib/utils/format";
@@ -24,21 +24,9 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 export const load: PageServerLoad = async (event) => {
-  // Require session authentication
-  const { user } = await requireAuth(event);
-
-  const { db } = await import("$lib/server/db");
   const projectId = event.params.id;
-
-  // Fetch project data - verify ownership
-  const [projectData] = await db
-    .select()
-    .from(project)
-    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
-
-  if (!projectData) {
-    throw error(404, { message: "Project not found" });
-  }
+  const { project: projectData } = await requireProjectOwnershipPage(event, projectId);
+  const db = await getDbClient(event.locals);
 
   // Parse query parameters
   const url = event.url;

--- a/src/routes/(app)/projects/[id]/incidents/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/incidents/+page.server.ts
@@ -1,9 +1,9 @@
-import { error } from "@sveltejs/kit";
 import { and, count, desc, eq, gte, lt, or, type SQL } from "drizzle-orm";
 import { INCIDENT_CONFIG } from "$lib/server/config";
-import { incident, project } from "$lib/server/db/schema";
-import { requireAuth } from "$lib/server/utils/auth-guard";
+import { getDbClient } from "$lib/server/db/db";
+import { incident } from "$lib/server/db/schema";
 import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
+import { requireProjectOwnershipPage } from "$lib/server/utils/project-guard";
 import { getIncidentStatus } from "$lib/server/utils/incidents";
 import {
   INCIDENT_RANGES,
@@ -23,18 +23,9 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 export const load: PageServerLoad = async (event) => {
-  const { user } = await requireAuth(event);
-  const { db } = await import("$lib/server/db");
   const projectId = event.params.id;
-
-  const [projectData] = await db
-    .select()
-    .from(project)
-    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
-
-  if (!projectData) {
-    throw error(404, { message: "Project not found" });
-  }
+  const { project: projectData } = await requireProjectOwnershipPage(event, projectId);
+  const db = await getDbClient(event.locals);
 
   const params = event.url.searchParams;
   const limit = clamp(

--- a/src/routes/(app)/projects/[id]/settings/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/settings/+page.server.ts
@@ -1,26 +1,14 @@
-import { error } from "@sveltejs/kit";
-import { and, count, eq, min } from "drizzle-orm";
+import { count, eq, min } from "drizzle-orm";
 import { RETENTION_CONFIG } from "$lib/server/config";
-import { log, project } from "$lib/server/db/schema";
-import { requireAuth } from "$lib/server/utils/auth-guard";
+import { getDbClient } from "$lib/server/db/db";
+import { log } from "$lib/server/db/schema";
+import { requireProjectOwnershipPage } from "$lib/server/utils/project-guard";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
-  // Require session authentication
-  const { user } = await requireAuth(event);
-
-  const { db } = await import("$lib/server/db");
   const projectId = event.params.id;
-
-  // Fetch project data - verify ownership
-  const [projectData] = await db
-    .select()
-    .from(project)
-    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
-
-  if (!projectData) {
-    throw error(404, { message: "Project not found" });
-  }
+  const { project: projectData } = await requireProjectOwnershipPage(event, projectId);
+  const db = await getDbClient(event.locals);
 
   // Get log stats: total count and oldest log date
   const [logStats] = await db

--- a/src/routes/(app)/projects/[id]/stats/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/stats/+page.server.ts
@@ -1,27 +1,15 @@
-import { error } from "@sveltejs/kit";
 import { and, count, eq, gte, type SQL } from "drizzle-orm";
-import { log, project } from "$lib/server/db/schema";
-import { requireAuth } from "$lib/server/utils/auth-guard";
+import { getDbClient } from "$lib/server/db/db";
+import { log } from "$lib/server/db/schema";
+import { requireProjectOwnershipPage } from "$lib/server/utils/project-guard";
 import { getTimeRangeStart } from "$lib/utils/format";
 import { parseTimeRange } from "$lib/utils/time-range";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
-  // Require session authentication
-  const { user } = await requireAuth(event);
-
-  const { db } = await import("$lib/server/db");
   const projectId = event.params.id;
-
-  // Fetch project data - verify ownership
-  const [projectData] = await db
-    .select()
-    .from(project)
-    .where(and(eq(project.id, projectId), eq(project.ownerId, user.id)));
-
-  if (!projectData) {
-    throw error(404, { message: "Project not found" });
-  }
+  const { project: projectData } = await requireProjectOwnershipPage(event, projectId);
+  const db = await getDbClient(event.locals);
 
   // Parse query parameters - default to 24h for stats overview
   const url = event.url;

--- a/tests/integration/pages/project-page-loaders.integration.test.ts
+++ b/tests/integration/pages/project-page-loaders.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for (app) page server loaders.
+ *
+ * Proves that:
+ * 1. Page loaders route DB access through getDbClient(event.locals), so an
+ *    injected PGlite test DB is honoured (the seam works end-to-end).
+ * 2. A non-owner receives a SvelteKit 404 error (error PAGE, not a JSON blob)
+ *    for each migrated loader — preserving the existence-hiding invariant.
+ */
+
+import type { HttpError } from "@sveltejs/kit";
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { createAuth } from "$lib/server/auth";
+import type * as schema from "$lib/server/db/schema";
+import { setupTestDatabase } from "$lib/server/db/test-db";
+import { getSession } from "$lib/server/session";
+import { seedProject } from "../../fixtures/db";
+
+// Import load functions as any to avoid the void | PageData union type issues
+// from SvelteKit's generated types in test contexts
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LoadFn = (event: never) => Promise<any>;
+
+const loadDashboard = (await import("../../../src/routes/(app)/+page.server")).load as LoadFn;
+const loadProjectLogs = (await import("../../../src/routes/(app)/projects/[id]/+page.server"))
+  .load as LoadFn;
+const loadProjectSettings = (
+  await import("../../../src/routes/(app)/projects/[id]/settings/+page.server")
+).load as LoadFn;
+const loadProjectStats = (
+  await import("../../../src/routes/(app)/projects/[id]/stats/+page.server")
+).load as LoadFn;
+const loadProjectIncidents = (
+  await import("../../../src/routes/(app)/projects/[id]/incidents/+page.server")
+).load as LoadFn;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createLoadEvent(
+  db: PgliteDatabase<typeof schema>,
+  params: Record<string, string>,
+  locals: Partial<App.Locals>,
+  url = "http://localhost:5173/",
+) {
+  return {
+    locals: { db, ...locals },
+    params,
+    url: new URL(url),
+    platform: undefined,
+    route: { id: "" },
+    isDataRequest: false,
+    isSubRequest: false,
+    isRemoteRequest: false,
+    tracing: null,
+    request: new Request(url),
+    cookies: {
+      get: () => undefined,
+      getAll: () => [],
+      set: () => {},
+      delete: () => {},
+      serialize: () => "",
+    },
+    fetch: globalThis.fetch,
+    getClientAddress: () => "127.0.0.1",
+    setHeaders: () => {},
+    depends: () => {},
+    parent: async () => ({}),
+  } as unknown;
+}
+
+async function createAuthenticatedLocals(
+  db: PgliteDatabase<typeof schema>,
+  auth: ReturnType<typeof createAuth>,
+  email: string,
+): Promise<{ locals: Partial<App.Locals>; userId: string }> {
+  const result = await auth.api.signUpEmail({
+    body: { email, password: "SecureP@ssw0rd123", name: "Test User" },
+  });
+
+  const sessionData = await getSession(
+    new Request("http://localhost:5173", {
+      headers: { cookie: `better-auth.session_token=${result.token}` },
+    }).headers,
+    db,
+  );
+  if (!sessionData) throw new Error("Session data must not be null");
+
+  return {
+    locals: { user: sessionData.user, session: sessionData.session },
+    userId: sessionData.user.id,
+  };
+}
+
+async function expectSvelteKit404(promise: Promise<unknown>): Promise<void> {
+  try {
+    await promise;
+    expect.fail("Expected a SvelteKit 404 error to be thrown");
+  } catch (err) {
+    const httpError = err as HttpError;
+    expect(httpError.status).toBe(404);
+    expect(httpError.body).toMatchObject({ message: "Project not found" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("(app) page loaders — injected PGlite DB seam", () => {
+  let db: PgliteDatabase<typeof schema>;
+  let cleanup: () => Promise<void>;
+  let auth: ReturnType<typeof createAuth>;
+  let owner: { locals: Partial<App.Locals>; userId: string };
+  let nonOwner: { locals: Partial<App.Locals>; userId: string };
+
+  beforeEach(async () => {
+    const setup = await setupTestDatabase();
+    db = setup.db;
+    cleanup = setup.cleanup;
+    auth = createAuth(db);
+
+    owner = await createAuthenticatedLocals(db, auth, "owner@example.com");
+    nonOwner = await createAuthenticatedLocals(db, auth, "nonowner@example.com");
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // Dashboard (root list loader)
+  // -------------------------------------------------------------------------
+  describe("(app)/+page.server.ts — dashboard list loader", () => {
+    it("returns only the authenticated owner's projects via injected PGlite DB", async () => {
+      const ownedProject = await seedProject(db, { name: "owned-project", ownerId: owner.userId });
+      await seedProject(db, { name: "other-project", ownerId: nonOwner.userId });
+
+      const event = createLoadEvent(db, {}, owner.locals);
+      const data = await loadDashboard(event as never);
+
+      expect(data.projects).toHaveLength(1);
+      expect(data.projects[0]!.id).toBe(ownedProject.id);
+    });
+
+    it("returns empty array when owner has no projects", async () => {
+      const event = createLoadEvent(db, {}, owner.locals);
+      const data = await loadDashboard(event as never);
+      expect(data.projects).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Projects/[id] — logs loader
+  // -------------------------------------------------------------------------
+  describe("(app)/projects/[id]/+page.server.ts — logs loader", () => {
+    it("returns project data via injected PGlite DB for the owner", async () => {
+      const proj = await seedProject(db, { name: "test-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, owner.locals);
+      const data = await loadProjectLogs(event as never);
+
+      expect(data.project.id).toBe(proj.id);
+      expect(data.project.name).toBe("test-proj");
+    });
+
+    it("throws SvelteKit 404 for a non-owner (existence hidden)", async () => {
+      const proj = await seedProject(db, { name: "other-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, nonOwner.locals);
+      await expectSvelteKit404(loadProjectLogs(event as never));
+    });
+
+    it("throws SvelteKit 404 for a project that does not exist", async () => {
+      const event = createLoadEvent(db, { id: "nonexistent-id" }, owner.locals);
+      await expectSvelteKit404(loadProjectLogs(event as never));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Projects/[id]/stats — stats loader
+  // -------------------------------------------------------------------------
+  describe("(app)/projects/[id]/stats/+page.server.ts — stats loader", () => {
+    it("returns stats data via injected PGlite DB for the owner", async () => {
+      const proj = await seedProject(db, { name: "stats-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, owner.locals);
+      const data = await loadProjectStats(event as never);
+
+      expect(data.project.id).toBe(proj.id);
+      expect(data.stats).toBeDefined();
+    });
+
+    it("throws SvelteKit 404 for a non-owner", async () => {
+      const proj = await seedProject(db, { name: "stats-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, nonOwner.locals);
+      await expectSvelteKit404(loadProjectStats(event as never));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Projects/[id]/settings — settings loader
+  // -------------------------------------------------------------------------
+  describe("(app)/projects/[id]/settings/+page.server.ts — settings loader", () => {
+    it("returns settings data via injected PGlite DB for the owner", async () => {
+      const proj = await seedProject(db, { name: "settings-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, owner.locals);
+      const data = await loadProjectSettings(event as never);
+
+      expect(data.project.id).toBe(proj.id);
+      expect(data.project.retentionDays).toBeDefined();
+    });
+
+    it("throws SvelteKit 404 for a non-owner", async () => {
+      const proj = await seedProject(db, { name: "settings-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, nonOwner.locals);
+      await expectSvelteKit404(loadProjectSettings(event as never));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Projects/[id]/incidents — incidents loader
+  // -------------------------------------------------------------------------
+  describe("(app)/projects/[id]/incidents/+page.server.ts — incidents loader", () => {
+    it("returns incidents data via injected PGlite DB for the owner", async () => {
+      const proj = await seedProject(db, { name: "incidents-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, owner.locals);
+      const data = await loadProjectIncidents(event as never);
+
+      expect(data.project.id).toBe(proj.id);
+      expect(data.incidents).toBeDefined();
+    });
+
+    it("throws SvelteKit 404 for a non-owner", async () => {
+      const proj = await seedProject(db, { name: "incidents-proj", ownerId: owner.userId });
+
+      const event = createLoadEvent(db, { id: proj.id }, nonOwner.locals);
+      await expectSvelteKit404(loadProjectIncidents(event as never));
+    });
+  });
+});


### PR DESCRIPTION
## Plan 016 — Unify `(app)` page-loader ownership checks and DB access through the existing seams (finding F13)

The API routes use `requireProjectOwnership` (auth+ownership, 404 hides existence) and `getDbClient(locals)` (test-injectable DB). The `(app)` page loaders used **neither** — they hand-rolled the ownership query 4× and reached for the DB three different ways, bypassing the test seam and copy-pasting the authorization rule.

### Changes
- **project-guard.ts**: extracted private `findOwnedProject` (the single shared auth+ownership query); `requireProjectOwnership` now delegates to it (**API JSON-404 contract unchanged**); added `requireProjectOwnershipPage` which `throw`s `error(404, …)` so the loader renders the SvelteKit **error page** (the `throw` vs `return Response` distinction is the whole point).
- **4 project loaders** (`[id]/`, `stats/`, `settings/`, `incidents/`): hand-rolled block → `requireProjectOwnershipPage(event, id)` + `getDbClient(event.locals)`; removed now-unused imports.
- **Root `(app)/+page.server.ts`**: singleton `import { db }` → `getDbClient(event.locals)` (list loader; keeps `requireAuth`).
- **tests/integration/pages/project-page-loaders.integration.test.ts** (new, 11 tests): PGlite-injection seam works for all 5 loaders (previously untestable); non-owner → **404 error page** (not JSON, not 500) for all 4 project loaders; dashboard lists only the owner's projects.
- **plans/README.md**: plan 016 status → `done`.

### Security invariant preserved (verified)
Non-owner access to an *existing* project still yields a 404 error page (existence hidden). The new tests assert `httpError.status === 404` + `{message: "Project not found"}`. **Regression-proven**: reverting the dashboard loader to the singleton import fails the new suite (`$env/dynamic/private`), confirming the `locals.db` seam is genuinely exercised. API JSON-404 contract unchanged (authorization tests 13/13).

### Verification
- `test:integration` 330/330 (incl. 11 new + logs 91 + authorization 13 + incidents 25); `test:unit` 355
- `grep` confirms the hand-rolled ownership query and all `await import("$lib/server/db")` / `import { db }` are gone from `(app)`.
- `vp check` 0, `bun run check` 0, `knip` clean.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass.
