### PR TITLE
chore(release): v1.1.0 (app + TS/Python SDKs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logwell",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logwell"
-version = "1.0.5"
+version = "1.1.0"
 description = "Official Python SDK for Logwell logging platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "logwell"
-version = "1.0.5"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logwell",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Official TypeScript SDK for Logwell logging platform",
   "keywords": [
     "logging",


### PR DESCRIPTION
## Release v1.1.0 — app + TypeScript/Python SDKs

Cuts the **minor** release covering the 16 advisory remediation PRs (#134–#149: findings F1–F18). Minor, not patch, because this batch ships a **DB migration** operators must run (`0010`, full `log` table rewrite under `ACCESS EXCLUSIVE` — maintenance window), a P1 SSE data-loss fix, and behavior changes (auth secret now required outside `NODE_ENV=development`; stricter CSRF; SSE payload drops `search`; additive `total_is_capped` API field).

### Version bumps
- **App**: `1.0.13` → `1.1.0` (`package.json`)
- **TypeScript SDK**: `1.0.5` → `1.1.0` (`sdks/typescript/package.json`) — dropped EOL Node 18 (now `>=20`)
- **Python SDK**: `1.0.5` → `1.1.0` (`sdks/python/pyproject.toml` + `uv.lock`) — dropped EOL Python 3.9 (now `>=3.10`)
- Go SDK: unchanged (no release)

### Release mechanics (for awareness)
- Merging this PR triggers `sdk-typescript.yml` / `sdk-python.yml` on `main` → they detect the new versions and **publish to npm/JSR/PyPI**.
- The **app Docker release** is cut by pushing the `v1.1.0` tag (→ `release.yml`), done after merge.
- SDK release-marker tags (`sdks/typescript@v1.1.0`, `sdks/python@v1.1.0`) pushed after publish, per the AGENTS.md convention.

`vp check` green; lockfiles synced (root + TS bun.lock unaffected; `uv.lock` regenerated to 1.1.0).
