### PR TITLE
chore(release): bump jsr.json to v1.1.0 for JSR publish

### DIFF
--- a/sdks/typescript/jsr.json
+++ b/sdks/typescript/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@divkix/logwell",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": "./src/index.ts"
 }


### PR DESCRIPTION
## Follow-up: bump `jsr.json` to v1.1.0 (JSR publish)

The TS SDK release (#150) bumped `sdks/typescript/package.json` → npm published `1.1.0` ✓, but `sdks/typescript/jsr.json` carries its **own** `version` field which I missed — it stayed at `1.0.5`. The `sdk-typescript.yml` JSR step reads the version from `jsr.json`, saw `1.0.5` already on JSR, and **skipped** (gracefully — that's why the run was green). So **JSR is still at 1.0.5** while npm is at 1.1.0.

This bumps `jsr.json` → `1.1.0`. On merge, `sdk-typescript.yml` re-runs and its JSR step (`npx jsr publish` via OIDC) detects `1.1.0` as new and publishes it; the npm step skips (1.1.0 already published).

`vp check` green. Only `sdks/typescript/jsr.json` changed.
