### PR TITLE
ci(release): shard e2e and bump login timeout to de-flake the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
   # E2E Tests (Playwright - all browsers)
   # =============================================================================
   test-e2e:
-    name: E2E Tests (${{ matrix.browser }})
+    name: E2E Tests (${{ matrix.browser }} ${{ matrix.shard }}/${{ matrix.total }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -157,6 +157,8 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium, firefox]
+        shard: [1, 2, 3]
+        total: [3]
 
     services:
       postgres:
@@ -232,13 +234,13 @@ jobs:
           ADMIN_PASSWORD: adminpass
 
       - name: Run E2E tests
-        run: bunx playwright test --project=${{ matrix.browser }}
+        run: bunx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/${{ matrix.total }}
 
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-${{ matrix.browser }}-${{ github.run_id }}
+          name: playwright-report-${{ matrix.browser }}-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/

--- a/tests/e2e/auth-guard.spec.ts
+++ b/tests/e2e/auth-guard.spec.ts
@@ -35,7 +35,7 @@ async function login(page: import("@playwright/test").Page) {
 
   // Click sign in and wait for redirect
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 test.describe("Auth Guard - Unauthenticated Access", () => {

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -32,7 +32,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/export-logs.spec.ts
+++ b/tests/e2e/export-logs.spec.ts
@@ -33,7 +33,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/incidents.spec.ts
+++ b/tests/e2e/incidents.spec.ts
@@ -13,7 +13,7 @@ async function login(page: Page) {
   await page.getByLabel(/username/i).fill(TEST_USER.username);
   await page.getByLabel(/password/i).fill(TEST_USER.password);
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 async function createProject(page: Page, name: string) {

--- a/tests/e2e/live-stream.spec.ts
+++ b/tests/e2e/live-stream.spec.ts
@@ -33,7 +33,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/log-stream.spec.ts
+++ b/tests/e2e/log-stream.spec.ts
@@ -34,7 +34,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -57,7 +57,7 @@ test.describe("Login Page", () => {
     await signInButton.click();
 
     // Wait for redirect to dashboard
-    await expect(page).toHaveURL("/", { timeout: 15000 });
+    await expect(page).toHaveURL("/", { timeout: 30000 });
   });
 
   test("should show error for invalid credentials", async ({ page }) => {
@@ -114,7 +114,7 @@ test.describe("Login Page", () => {
     await passwordInput.press("Enter");
 
     // Wait for redirect to dashboard
-    await expect(page).toHaveURL("/", { timeout: 15000 });
+    await expect(page).toHaveURL("/", { timeout: 30000 });
   });
 
   test("should disable form inputs during submission", async ({ page }) => {
@@ -179,7 +179,7 @@ test.describe("Login Page - Authentication State", () => {
     await page.getByRole("button", { name: /sign in/i }).click();
 
     // Wait for redirect to complete
-    await expect(page).toHaveURL("/", { timeout: 15000 });
+    await expect(page).toHaveURL("/", { timeout: 30000 });
 
     // Now try to visit login page again
     await page.goto("/login");

--- a/tests/e2e/otlp-ingestion.spec.ts
+++ b/tests/e2e/otlp-ingestion.spec.ts
@@ -14,7 +14,7 @@ async function login(page: Page) {
   await page.getByLabel(/password/i).fill(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 async function createProject(page: Page, name: string) {

--- a/tests/e2e/pagination.spec.ts
+++ b/tests/e2e/pagination.spec.ts
@@ -26,7 +26,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -32,7 +32,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -44,7 +44,7 @@ async function login(page: Page) {
   await expect(passwordInput).toHaveValue(TEST_USER.password);
 
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 /**

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -28,7 +28,7 @@ async function login(page: Page) {
 
   // Click sign in and wait for redirect
   await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
+  await expect(page).toHaveURL("/", { timeout: 30000 });
 }
 
 test.describe("Theme Toggle", () => {


### PR DESCRIPTION
## ci(release): shard e2e + de-flake login to unblock the v1.1.0 release

The app `v1.1.0` release was blocked: `release.yml`'s `test-e2e` ran the **full Playwright suite unsharded** per browser (`matrix: browser:[chromium,firefox]`), ~3× the per-job load of `ci.yml`'s **3-way-sharded** e2e — so the cold-server better-auth login (`toHaveURL("/", { timeout: 15000 })`) timed out and failed the release twice (chromium → firefox cancelled → `docker-publish`/`github-release` skipped). `ci.yml` (sharded) passed the same code on every PR.

### Changes
- **.github/workflows/release.yml**: shard `test-e2e` — matrix is now `browser:[chromium,firefox] × shard:[1,2,3]` (6 jobs, each runs ⅓ of the suite per browser), `name` includes the shard, the command appends `--shard=${{ matrix.shard }}/${{ matrix.total }}`, and the failure-artifact name is per-shard-unique. Matches `ci.yml`'s reliable pattern; downstream `needs` unchanged.
- **12 e2e spec files**: bump the `login()` helper redirect assertion `toHaveURL("/", { timeout: 15000 })` → `30000` (matching `stats.spec.ts`, which already used 30s reliably). Only the cold-login redirect was touched — bare `toHaveURL("/")` and the 5s/10s assertions in test bodies are unchanged.

### Verification
- `vp check` 0, `bun run check` 0; release.yml validated with a YAML parser; scope = only release.yml + e2e specs.
- This PR's own `ci.yml` chromium e2e now runs with the 30s login timeout (the de-flake) — a live check that login is reliable.

After merge, the `v1.1.0` tag will be re-cut on the fixed commit so `release.yml` runs sharded and the GitHub Release/GHCR image land. Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh).
