### PR TITLE
ci/test(e2e): fix release login flake — rate-limit bypass + retry-based sign-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
         shard: [1, 2, 3]
         total: [3]
 
+    env:
+      # Match ci.yml: the e2e suite performs many logins; without this the
+      # default per-IP login rate limit (10/min) 429s sign-ins mid-run, so
+      # `toHaveURL("/")` never resolves and shards fail/time out.
+      RATE_LIMIT_LOGIN_RPM: 10000
+
     services:
       postgres:
         image: postgres:18-alpine

--- a/tests/e2e/auth-guard.spec.ts
+++ b/tests/e2e/auth-guard.spec.ts
@@ -20,22 +20,12 @@ async function login(page: import("@playwright/test").Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  // Clear and fill username, verify value
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  // Clear and fill password, verify value
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  // Click sign in and wait for redirect
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 test.describe("Auth Guard - Unauthenticated Access", () => {

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -20,19 +20,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/export-logs.spec.ts
+++ b/tests/e2e/export-logs.spec.ts
@@ -21,19 +21,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/incidents.spec.ts
+++ b/tests/e2e/incidents.spec.ts
@@ -10,10 +10,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  await page.getByLabel(/username/i).fill(TEST_USER.username);
-  await page.getByLabel(/password/i).fill(TEST_USER.password);
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 async function createProject(page: Page, name: string) {

--- a/tests/e2e/live-stream.spec.ts
+++ b/tests/e2e/live-stream.spec.ts
@@ -21,19 +21,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/log-stream.spec.ts
+++ b/tests/e2e/log-stream.spec.ts
@@ -22,19 +22,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/otlp-ingestion.spec.ts
+++ b/tests/e2e/otlp-ingestion.spec.ts
@@ -10,11 +10,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  await page.getByLabel(/username/i).fill(TEST_USER.username);
-  await page.getByLabel(/password/i).fill(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 async function createProject(page: Page, name: string) {

--- a/tests/e2e/pagination.spec.ts
+++ b/tests/e2e/pagination.spec.ts
@@ -14,19 +14,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -20,19 +20,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -32,19 +32,12 @@ async function login(page: Page) {
   await page.goto("/login");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/stats.spec.ts
+++ b/tests/e2e/stats.spec.ts
@@ -18,26 +18,15 @@ const TEST_USER = {
  * Helper to perform login with retry logic for cold start resilience
  */
 async function login(page: Page) {
-  // Wait for the server to be ready
   await page.goto("/login");
-  await page.waitForLoadState("networkidle");
-  await page.waitForSelector("form", { timeout: 10000 });
+  await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  await usernameInput.click();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  await passwordInput.click();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  await page.getByRole("button", { name: /sign in/i }).click();
-
-  // Wait for navigation with retry
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 /**

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -7,28 +7,14 @@ const TEST_USER = {
 
 async function login(page: Page) {
   await page.goto("/login");
-  await page.waitForLoadState("networkidle");
   await page.waitForSelector("form");
 
-  const usernameInput = page.getByLabel(/username/i);
-  const passwordInput = page.getByLabel(/password/i);
-
-  // Wait for Svelte hydration
-  await page.waitForTimeout(500);
-
-  // Clear and fill username - use clear() first to ensure clean state
-  await usernameInput.clear();
-  await usernameInput.fill(TEST_USER.username);
-  await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-  // Clear and fill password
-  await passwordInput.clear();
-  await passwordInput.fill(TEST_USER.password);
-  await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-  // Click sign in and wait for redirect
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL("/", { timeout: 30000 });
+  await expect(async () => {
+    await page.getByLabel(/username/i).fill(TEST_USER.username);
+    await page.getByLabel(/password/i).fill(TEST_USER.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL("/", { timeout: 10000 });
+  }).toPass({ timeout: 45000 });
 }
 
 test.describe("Theme Toggle", () => {


### PR DESCRIPTION
## Fix the e2e login flake blocking the v1.1.0 release (two independent causes)

The v1.1.0 release pipeline kept failing e2e on login (`toHaveURL("/")` stuck on `/login`). Two distinct root causes, both fixed here:

### 1. Missing login rate-limit bypass in `release.yml` (release-specific, deterministic)
`ci.yml`'s e2e sets `RATE_LIMIT_LOGIN_RPM: 10000`; `release.yml`'s e2e never did. So once a shard exceeded the default 10 logins/min/IP, sign-ins got **429'd** and the shard failed. → added the same env to `release.yml`'s `test-e2e`.

### 2. Login hydration race (affects `ci.yml` too — caused the periodic rerun-to-green)
The `login()` helpers clicked "sign in" before SvelteKit hydrated the form's submit handler, so the click no-op'd and the page never redirected. Neither sharding, the 30s timeout (#153), nor the rate-limit env fixes this. → all **12 `login()` helpers** now retry the sign-in as a unit via Playwright's `expect(async () => { fill; fill; click; await expect(page).toHaveURL("/", {timeout:10000}); }).toPass({ timeout: 45000 })`, so a pre-hydration attempt is simply retried. Removed the old ad-hoc workarounds (`toHaveValue`, `waitForTimeout`, `networkidle`).

### Verification
- `vp check` 0, `bun run check` 0; scope = `release.yml` env + 12 e2e login helpers only (no app/src).
- This PR's own ci.yml e2e exercises the retry-based login — a live check.

After merge I'll re-cut `v1.1.0` so `release.yml` runs with all fixes (rate-limit bypass + sharding + retry login) and the GHCR image + GitHub Release finally land. (Builds on #153's sharding + 30s timeout.)