### PR TITLE
test(e2e): harden login.spec.ts against the login hydration race

### DIFF
--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -39,82 +39,57 @@ test.describe("Login Page", () => {
   });
 
   test("should redirect to / after successful login", async ({ page }) => {
-    // Fill in credentials
-    const usernameInput = page.getByLabel(/username/i);
-    const passwordInput = page.getByLabel(/password/i);
-
-    // Clear any pre-filled values and fill with test credentials
-    await usernameInput.click();
-    await usernameInput.fill(TEST_USER.username);
-    await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-    await passwordInput.click();
-    await passwordInput.fill(TEST_USER.password);
-    await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-    // Click sign in button
-    const signInButton = page.getByRole("button", { name: /sign in/i });
-    await signInButton.click();
-
-    // Wait for redirect to dashboard
-    await expect(page).toHaveURL("/", { timeout: 30000 });
+    // Wrap interaction + assertion in toPass to retry if a pre-hydration no-op occurs
+    await expect(async () => {
+      await page.getByLabel(/username/i).fill(TEST_USER.username);
+      await page.getByLabel(/password/i).fill(TEST_USER.password);
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page).toHaveURL("/", { timeout: 10000 });
+    }).toPass({ timeout: 45000 });
   });
 
   test("should show error for invalid credentials", async ({ page }) => {
-    // Fill in wrong password
-    const usernameInput = page.getByLabel(/username/i);
-    const passwordInput = page.getByLabel(/password/i);
-
-    await usernameInput.fill(TEST_USER.username);
-    await passwordInput.fill("WrongPassword123!");
-
-    // Click sign in button
-    await page.getByRole("button", { name: /sign in/i }).click();
-
-    // Wait for error message to appear
-    await expect(page.getByText(/invalid|incorrect|wrong|credentials/i)).toBeVisible({
-      timeout: 10000,
-    });
+    // Wrap interaction + error assertion in toPass to survive pre-hydration no-ops
+    await expect(async () => {
+      await page.getByLabel(/username/i).fill(TEST_USER.username);
+      await page.getByLabel(/password/i).fill("WrongPassword123!");
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page.getByText(/invalid|incorrect|wrong|credentials/i)).toBeVisible({
+        timeout: 10000,
+      });
+    }).toPass({ timeout: 45000 });
 
     // Should stay on login page
     await expect(page).toHaveURL(/\/login/);
   });
 
   test("should show error for non-existent user", async ({ page }) => {
-    // Fill in non-existent username
-    await page.getByLabel(/username/i).fill("nonexistentuser");
-    await page.getByLabel(/password/i).fill("SomePassword123!");
-
-    // Click sign in button
-    await page.getByRole("button", { name: /sign in/i }).click();
-
-    // Wait for error message to appear (better-auth returns generic error to prevent user enumeration)
-    await expect(page.getByText(/invalid username or password/i)).toBeVisible({
-      timeout: 10000,
-    });
+    // Wrap interaction + error assertion in toPass to survive pre-hydration no-ops
+    await expect(async () => {
+      await page.getByLabel(/username/i).fill("nonexistentuser");
+      await page.getByLabel(/password/i).fill("SomePassword123!");
+      await page.getByRole("button", { name: /sign in/i }).click();
+      // better-auth returns generic error to prevent user enumeration
+      await expect(page.getByText(/invalid username or password/i)).toBeVisible({
+        timeout: 10000,
+      });
+    }).toPass({ timeout: 45000 });
 
     // Should stay on login page
     await expect(page).toHaveURL(/\/login/);
   });
 
   test("should submit form when Enter key is pressed", async ({ page }) => {
-    // Fill in credentials
-    const usernameInput = page.getByLabel(/username/i);
-    const passwordInput = page.getByLabel(/password/i);
-
-    await usernameInput.click();
-    await usernameInput.fill(TEST_USER.username);
-    await expect(usernameInput).toHaveValue(TEST_USER.username);
-
-    await passwordInput.click();
-    await passwordInput.fill(TEST_USER.password);
-    await expect(passwordInput).toHaveValue(TEST_USER.password);
-
-    // Press Enter key instead of clicking button
-    await passwordInput.press("Enter");
-
-    // Wait for redirect to dashboard
-    await expect(page).toHaveURL("/", { timeout: 30000 });
+    // Wrap interaction + assertion in toPass to retry if a pre-hydration no-op occurs
+    await expect(async () => {
+      const usernameInput = page.getByLabel(/username/i);
+      const passwordInput = page.getByLabel(/password/i);
+      await usernameInput.fill(TEST_USER.username);
+      await passwordInput.fill(TEST_USER.password);
+      // Press Enter key instead of clicking button
+      await passwordInput.press("Enter");
+      await expect(page).toHaveURL("/", { timeout: 10000 });
+    }).toPass({ timeout: 45000 });
   });
 
   test("should disable form inputs during submission", async ({ page }) => {
@@ -136,25 +111,23 @@ test.describe("Login Page", () => {
   });
 
   test("should show validation error for empty username", async ({ page }) => {
-    // Leave username empty, fill password
-    await page.getByLabel(/password/i).fill(TEST_USER.password);
-
-    // Click sign in button
-    await page.getByRole("button", { name: /sign in/i }).click();
-
-    // Should show validation error - be specific about the error text
-    await expect(page.getByText("Username is required")).toBeVisible();
+    // Wrap interaction + assertion in toPass; leave username EMPTY intentionally
+    await expect(async () => {
+      // Only fill password — empty username is the whole point of this test
+      await page.getByLabel(/password/i).fill(TEST_USER.password);
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page.getByText("Username is required")).toBeVisible();
+    }).toPass({ timeout: 45000 });
   });
 
   test("should show validation error for empty password", async ({ page }) => {
-    // Fill username, leave password empty
-    await page.getByLabel(/username/i).fill(TEST_USER.username);
-
-    // Click sign in button
-    await page.getByRole("button", { name: /sign in/i }).click();
-
-    // Should show validation error - be specific about the error text
-    await expect(page.getByText("Password is required")).toBeVisible();
+    // Wrap interaction + assertion in toPass; leave password EMPTY intentionally
+    await expect(async () => {
+      // Only fill username — empty password is the whole point of this test
+      await page.getByLabel(/username/i).fill(TEST_USER.username);
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page.getByText("Password is required")).toBeVisible();
+    }).toPass({ timeout: 45000 });
   });
 });
 
@@ -167,19 +140,13 @@ test.describe("Login Page - Authentication State", () => {
     await page.goto("/login");
     await page.waitForSelector("form");
 
-    const usernameInput = page.getByLabel(/username/i);
-    const passwordInput = page.getByLabel(/password/i);
-
-    await usernameInput.click();
-    await usernameInput.fill(TEST_USER.username);
-    await passwordInput.click();
-    await passwordInput.fill(TEST_USER.password);
-
-    // Click sign in button
-    await page.getByRole("button", { name: /sign in/i }).click();
-
-    // Wait for redirect to complete
-    await expect(page).toHaveURL("/", { timeout: 30000 });
+    // Wrap the login interaction in toPass to survive pre-hydration no-ops
+    await expect(async () => {
+      await page.getByLabel(/username/i).fill(TEST_USER.username);
+      await page.getByLabel(/password/i).fill(TEST_USER.password);
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page).toHaveURL("/", { timeout: 10000 });
+    }).toPass({ timeout: 45000 });
 
     // Now try to visit login page again
     await page.goto("/login");


### PR DESCRIPTION
## test(e2e): harden login.spec.ts against the hydration race

Final cleanup of the login flake. PR #154 fixed the 12 reusable `login()` helpers, but `login.spec.ts` (the login *page's own* test suite) still had bare clicks/keypresses that could no-op before SvelteKit hydrates the form handler. This closes that gap across the whole e2e suite.

### Change (test-only, `tests/e2e/login.spec.ts`)
Each interacting test now retries its interaction + its **own** expected outcome via `expect(async () => { … }).toPass({ timeout: 45000 })`, re-filling each attempt — so a pre-hydration no-op is retried, but **each test keeps its exact intent**:
- success-redirect (#1) and Enter-key (#2, still `press("Enter")`, not click) → retry until `toHaveURL("/")`;
- invalid-creds (#3) / non-existent-user (#4) → retry until the **error text** shows, still asserting it stays on `/login` afterward;
- empty-username (#5) / empty-password (#6) → retry until the **validation error** shows, **never filling** the field that must stay empty;
- the `test.skip` auth-state test hardened too (stays skipped).
- Pure-visibility / focus / disable-inputs tests left untouched.

### Verification
- `vp check` 0, `bun run check` 0; scope = only `login.spec.ts`; TEST_USER + describe/beforeEach intact.
- e2e env has `RATE_LIMIT_LOGIN_RPM: 10000`, so retried submits aren't rate-limited; auth/validation errors are idempotent.

Implemented by Sonnet 4.6 (high), reviewed by Opus 4.8 (xhigh) — approved first pass. v1.1.0 is already released; this is pure test-reliability hardening.
