### PR TITLE
chore(lint): exclude .claude from vp fmt/lint; lint TS SDK in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,10 @@
-vp check && bun run knip
+set -e
+
+vp check
+bun run knip
+
+# sdks/typescript is excluded from the root vp check (its own tsconfig + vp check + CI).
+# Lint it here only when its files are staged, so unrelated commits aren't slowed.
+if git diff --cached --name-only --diff-filter=ACMR | grep -q '^sdks/typescript/'; then
+  bun run --cwd sdks/typescript check
+fi

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,15 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix",
   },
-  fmt: {},
+  fmt: {
+    // Oxfmt does not honor .gitignore; .claude/workflows/*.js are gitignored,
+    // machine-generated Claude Code workflow scripts — don't format them.
+    ignorePatterns: [".claude/**"],
+  },
   lint: {
-    ignorePatterns: ["sdks/**"],
+    // sdks/** is independently linted (sdks/typescript has its own vp check +
+    // tsconfig + CI; go/python have their own tools). .claude/** is generated.
+    ignorePatterns: ["sdks/**", ".claude/**"],
     jsPlugins: [{ name: "vite-plus", specifier: "vite-plus/oxlint-plugin" }],
     rules: { "vite-plus/prefer-vite-plus-imports": "error" },
     options: { typeAware: true, typeCheck: true },


### PR DESCRIPTION
## What

- **fmt + lint now ignore `.claude/**`** in `vite.config.ts`. Oxfmt doesn't honor `.gitignore`, so it was scanning `.claude/workflows/*.js` (gitignored, machine-generated Claude Code workflow scripts) and failing every commit with "Formatting issues found". The type-aware lint is also excluded from them.
- **`.husky/pre-commit` now also lints the TS SDK** via `bun run --cwd sdks/typescript check`, but **only when `sdks/typescript/**` is staged**. The root `vp check` deliberately excludes `sdks/**` (each SDK is a standalone package with its own tsconfig/toolchain + CI), which meant SDK lint/type issues only surfaced in CI — this closes that local gap without slowing unrelated commits.

## Why `sdks/**` stays excluded from the root lint
`sdks/typescript` is an independent vite-plus package (own `package.json`, `tsconfig.json`, `vp check`, `node_modules`) linted by `sdk-typescript.yml`; `sdks/go` and `sdks/python` use golangci-lint / ruff+mypy. Root `vp check` is type-aware and parses every tsconfig in the tree, so folding the SDK in collides the two tsconfig graphs (the SDK CI already stubs the root `.svelte-kit` tsconfig to avoid the reverse collision).

## Verification
- `vp check` → pass: 278 files formatted, 257 lint/type-clean.
- Pre-commit hook ran clean on this commit (no `--no-verify`); SDK check correctly skipped (no `sdks/typescript` files staged).

_Also serving as the first smoke test of ai-review on this repo._