### PR TITLE
chore: dedupe v1 ingest handlers (returning map + response builder)

### DIFF
--- a/src/lib/server/utils/ingest.ts
+++ b/src/lib/server/utils/ingest.ts
@@ -1,0 +1,55 @@
+import { log } from "$lib/server/db/schema";
+
+/**
+ * Column map shared by both ingest endpoints' insert `.returning(...)` calls.
+ *
+ * It lists every `log` column **except** the generated `search` tsvector, which
+ * must never be fetched into the SSE payload. Keeping a single definition means
+ * `/v1/logs` and `/v1/ingest` can never silently drift to emit different shapes.
+ */
+export const LOG_RETURNING_COLUMNS = {
+  id: log.id,
+  projectId: log.projectId,
+  incidentId: log.incidentId,
+  fingerprint: log.fingerprint,
+  serviceName: log.serviceName,
+  level: log.level,
+  message: log.message,
+  metadata: log.metadata,
+  timeUnixNano: log.timeUnixNano,
+  observedTimeUnixNano: log.observedTimeUnixNano,
+  severityNumber: log.severityNumber,
+  severityText: log.severityText,
+  body: log.body,
+  droppedAttributesCount: log.droppedAttributesCount,
+  flags: log.flags,
+  traceId: log.traceId,
+  spanId: log.spanId,
+  resourceAttributes: log.resourceAttributes,
+  resourceDroppedAttributesCount: log.resourceDroppedAttributesCount,
+  resourceSchemaUrl: log.resourceSchemaUrl,
+  scopeName: log.scopeName,
+  scopeVersion: log.scopeVersion,
+  scopeAttributes: log.scopeAttributes,
+  scopeDroppedAttributesCount: log.scopeDroppedAttributesCount,
+  scopeSchemaUrl: log.scopeSchemaUrl,
+  sourceFile: log.sourceFile,
+  lineNumber: log.lineNumber,
+  requestId: log.requestId,
+  userId: log.userId,
+  ipAddress: log.ipAddress,
+  timestamp: log.timestamp,
+} as const;
+
+/**
+ * Builds the JSON body shared by both ingest endpoints. `rejected`/`errors` are
+ * only included when at least one record was rejected.
+ */
+export function buildIngestResponse(accepted: number, rejected: number, errors: string[]) {
+  const response: { accepted: number; rejected?: number; errors?: string[] } = { accepted };
+  if (rejected > 0) {
+    response.rejected = rejected;
+    response.errors = errors;
+  }
+  return response;
+}

--- a/src/routes/v1/ingest/+server.ts
+++ b/src/routes/v1/ingest/+server.ts
@@ -7,6 +7,7 @@ import { log, project } from "$lib/server/db/schema";
 import { logEventBus, type StreamLog } from "$lib/server/events";
 import { ApiKeyError, validateApiKey } from "$lib/server/utils/api-key";
 import { requireJsonContentType } from "$lib/server/utils/content-type";
+import { buildIngestResponse, LOG_RETURNING_COLUMNS } from "$lib/server/utils/ingest";
 import {
   assignIncidentIds,
   prepareLogsForIncidents,
@@ -175,39 +176,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const insertedLogs: StreamLog[] = await (
             tx.insert(log).values(logEntries) as any
-          ).returning({
-            id: log.id,
-            projectId: log.projectId,
-            incidentId: log.incidentId,
-            fingerprint: log.fingerprint,
-            serviceName: log.serviceName,
-            level: log.level,
-            message: log.message,
-            metadata: log.metadata,
-            timeUnixNano: log.timeUnixNano,
-            observedTimeUnixNano: log.observedTimeUnixNano,
-            severityNumber: log.severityNumber,
-            severityText: log.severityText,
-            body: log.body,
-            droppedAttributesCount: log.droppedAttributesCount,
-            flags: log.flags,
-            traceId: log.traceId,
-            spanId: log.spanId,
-            resourceAttributes: log.resourceAttributes,
-            resourceDroppedAttributesCount: log.resourceDroppedAttributesCount,
-            resourceSchemaUrl: log.resourceSchemaUrl,
-            scopeName: log.scopeName,
-            scopeVersion: log.scopeVersion,
-            scopeAttributes: log.scopeAttributes,
-            scopeDroppedAttributesCount: log.scopeDroppedAttributesCount,
-            scopeSchemaUrl: log.scopeSchemaUrl,
-            sourceFile: log.sourceFile,
-            lineNumber: log.lineNumber,
-            requestId: log.requestId,
-            userId: log.userId,
-            ipAddress: log.ipAddress,
-            timestamp: log.timestamp,
-          });
+          ).returning(LOG_RETURNING_COLUMNS);
           return { insertedLogs, touchedIncidents };
         })
       : { insertedLogs: [], touchedIncidents: [] };
@@ -220,12 +189,5 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     logEventBus.emitIncident(touchedIncident);
   }
 
-  // Build response
-  const response: { accepted: number; rejected?: number; errors?: string[] } = { accepted };
-  if (rejected > 0) {
-    response.rejected = rejected;
-    response.errors = errors;
-  }
-
-  return json(response, { status: 200 });
+  return json(buildIngestResponse(accepted, rejected, errors), { status: 200 });
 };

--- a/src/routes/v1/logs/+server.ts
+++ b/src/routes/v1/logs/+server.ts
@@ -7,6 +7,7 @@ import { log, project } from "$lib/server/db/schema";
 import { logEventBus, type StreamLog } from "$lib/server/events";
 import { ApiKeyError, validateApiKey } from "$lib/server/utils/api-key";
 import { requireJsonContentType } from "$lib/server/utils/content-type";
+import { buildIngestResponse, LOG_RETURNING_COLUMNS } from "$lib/server/utils/ingest";
 import {
   assignIncidentIds,
   prepareLogsForIncidents,
@@ -19,15 +20,6 @@ import {
   OtlpValidationError,
 } from "$lib/server/utils/otlp";
 import { checkRateLimit, INGEST_RPM } from "$lib/server/utils/rate-limit";
-
-function buildIngestResponse(accepted: number, rejected: number, errors: string[]) {
-  const response: { accepted: number; rejected?: number; errors?: string[] } = { accepted };
-  if (rejected > 0) {
-    response.rejected = rejected;
-    response.errors = errors;
-  }
-  return response;
-}
 
 /**
  * POST /v1/logs (OTLP/HTTP JSON)
@@ -172,39 +164,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const insertedLogs: StreamLog[] = await (
             tx.insert(log).values(logEntries) as any
-          ).returning({
-            id: log.id,
-            projectId: log.projectId,
-            incidentId: log.incidentId,
-            fingerprint: log.fingerprint,
-            serviceName: log.serviceName,
-            level: log.level,
-            message: log.message,
-            metadata: log.metadata,
-            timeUnixNano: log.timeUnixNano,
-            observedTimeUnixNano: log.observedTimeUnixNano,
-            severityNumber: log.severityNumber,
-            severityText: log.severityText,
-            body: log.body,
-            droppedAttributesCount: log.droppedAttributesCount,
-            flags: log.flags,
-            traceId: log.traceId,
-            spanId: log.spanId,
-            resourceAttributes: log.resourceAttributes,
-            resourceDroppedAttributesCount: log.resourceDroppedAttributesCount,
-            resourceSchemaUrl: log.resourceSchemaUrl,
-            scopeName: log.scopeName,
-            scopeVersion: log.scopeVersion,
-            scopeAttributes: log.scopeAttributes,
-            scopeDroppedAttributesCount: log.scopeDroppedAttributesCount,
-            scopeSchemaUrl: log.scopeSchemaUrl,
-            sourceFile: log.sourceFile,
-            lineNumber: log.lineNumber,
-            requestId: log.requestId,
-            userId: log.userId,
-            ipAddress: log.ipAddress,
-            timestamp: log.timestamp,
-          });
+          ).returning(LOG_RETURNING_COLUMNS);
           return { insertedLogs, touchedIncidents };
         })
       : { insertedLogs: [], touchedIncidents: [] };


### PR DESCRIPTION
## Summary

Phase 2 (REVIEW tier) of the code-cleanup sweep. The two ingest handlers — `/v1/logs` (OTLP) and `/v1/ingest` (simple JSON) — each carried **byte-identical copies** of:

1. the insert `.returning(...)` column map (31 columns; the generated `search` tsvector deliberately excluded), and
2. the `{accepted, rejected?, errors?}` response-body builder.

Both are now extracted into a single `src/lib/server/utils/ingest.ts`:

- **`LOG_RETURNING_COLUMNS`** — one shared column map; both handlers call `.returning(LOG_RETURNING_COLUMNS)`.
- **`buildIngestResponse(accepted, rejected, errors)`** — moved out of `v1/logs` and reused by `v1/ingest` (previously inline).

## Why

AGENTS.md calls the explicit column map "the source of truth" for what gets serialized to SSE consumers. With two copies, adding a column to one map only would **silently diverge** the streamed log shape between the two ingest endpoints. Collapsing to one definition removes that drift risk. Net `-83 / +5` lines in the handlers.

## Behavior

Behavior-preserving: the column map and response shape are unchanged. The `as any` cast on the insert builder (documented `.returning()` union-overload workaround) is retained — only the argument is now the shared constant. The intentional 429 body-shape difference between the two endpoints is untouched.

## Validation (all match pre-change baseline)

- `bun run lint` (vp check): 258 files, 0 warnings/errors
- `bun run check` (svelte-check): 0 errors, 0 warnings
- `bun run knip`: clean
- `test:unit` 355, `test:component` 352, `test:integration` 330 — all pass (integration covers both ingest handlers' exact row + response shapes)
