### PR TITLE
docs(agents): Cloud Agent Postgres and Vite env gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,7 @@ The `plans/` directory is the durable **decision record** — self-contained han
 18. **API keys are write-only**: there is no read/query API by key (logs read only via the session UI). **Project names are unique per-owner**, not globally.
 19. **Per-log ingest errors are not request failures**: `/v1/ingest` returns **200** `{accepted, rejected, errors[]}` for bad records; only batch-level issues (`invalid_json`, `batch_too_large`, auth, rate-limit) return 4xx.
 20. **Login rate-limit proxy trust**: `event.getClientAddress()` trusts the first `X-Forwarded-For`, so per-IP login limiting is effective only behind a trusted proxy that overwrites XFF; direct deployments should set `RATE_LIMIT_LOGIN_RPM` accordingly or use such a proxy.
+21. **Cloud Agent VMs have no Docker.** Postgres is native 18 (`sudo pg_ctlcluster 18 main start`); `bun run db:start` (`docker compose`) will not work. Create role `root` / database `local` to match `.env.example`. Vite is a Node child of `bun run dev` and **does not inherit bun's automatic `.env` load** — `set -a && source .env && set +a` before starting the server, and pass `--host 0.0.0.0` so IPv4 health checks on `127.0.0.1:5173` succeed. Seeded admin is `admin` / `adminpass` (same as e2e).
 
 ## Agent skills
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a Cloud Agent gotcha to `AGENTS.md` so future agents do not follow the Docker-only local quick start.

Cloud Agent VMs in this environment do not run Docker Compose. Postgres is native 18 via `pg_ctlcluster`, Vite does not inherit bun's automatic `.env` load, and the dev server must bind `0.0.0.0` for IPv4 health checks.

The Cloud Agent environment install/start scripts are proposed separately in the Environment panel. Merging this PR is optional documentation; Save in the Environment panel is what activates the tested setup for future agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03fe9-9990-7ac3-97af-33885b0b4f33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03fe9-9990-7ac3-97af-33885b0b4f33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

