### PR TITLE
refactor(query): unify log-filter queries behind one log-query module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ src/
         test-db.ts          # PGlite schema-reflection engine for integration tests
       config/               # env.ts (validated env), performance.ts (tunables)
       jobs/                 # log-cleanup.ts, cleanup-scheduler.ts (retention sweeps)
-      utils/                # api-key, csrf, rate-limit, cursor, search, incidents, otlp, simple-ingest, ...
+      utils/                # ingest (pipeline), log-query, api-key, csrf, rate-limit, cursor, search, incidents, otlp, simple-ingest, ...
       events.ts             # logEventBus singleton (SSE pub/sub)
       error-handler.ts      # handleError() — sanitized errors + error IDs
     shared/schemas/         # Zod schemas shared by client/server/SDKs (project, log, incident)
@@ -171,7 +171,7 @@ Both ingest routes follow the same pipeline:
 
 **API keys** (`api-key.ts`): `lw_` + 32 url-safe chars, stored as **SHA-256 hex only** (plaintext shown once). In-process cache: positive 5 min, negative 30 s.
 
-**Simple-ingest contract** (`/v1/ingest`): per-log failures do **not** fail the request — **200** `{accepted}`, plus `{rejected, errors[]}` when any record is rejected. Only batch-level problems return 4xx (`unsupported_media_type`, `invalid_json`, `validation_error`, `batch_too_large`, `unauthorized`, `rate_limited`). Known wart: the 429 body is `{error}` on `/v1/logs` vs `{error,message}` on `/v1/ingest` (see `plans/README.md` rejected ledger). Metadata mapping: `request.id`→`requestId`, `enduser.id`→`userId`, `client.address`→`ipAddress`; top-level `service` → `serviceName` + `resourceAttributes."service.name"`; empty `{}` metadata stores as `NULL`.
+**Ingest pipeline** (`utils/ingest.ts:ingestLogs`): both `/v1` routes are thin adapters over one pipeline — shared guard → rate-limit → parse → transaction → broadcast. Adapters differ only in parsing (`parseOtlpIngestBody` / `parseSimpleIngestBody` → wide rows minus id/project/incident stamps). Both 429s return `{error,message}` + `Retry-After: 60` (SDKs key off status, not body). **Log-query module** (`utils/log-query.ts:queryLogs`): owns filter → where-clause → paged select for the logs route, export, and page loader (params-in/rows-out; throws `InvalidCursorError`, route maps to 400, loader falls back to first page). `cursor.ts`/`search.ts`/`capped-count.ts` stay until the incidents route migrates onto it. **Simple-ingest contract** (`/v1/ingest`): per-log failures do **not** fail the request — **200** `{accepted}`, plus `{rejected, errors[]}` when any record is rejected. Only batch-level problems return 4xx (`unsupported_media_type`, `invalid_json`, `validation_error`, `batch_too_large`, `unauthorized`, `rate_limited`). Metadata mapping: `request.id`→`requestId`, `enduser.id`→`userId`, `client.address`→`ipAddress`; top-level `service` → `serviceName` + `resourceAttributes."service.name"`; empty `{}` metadata stores as `NULL`.
 
 **Incident grouping** is **error/fatal only**; other levels get `null` fingerprint/incidentId (but still get `serviceName`). `highestLevel` collapses via `LEVEL_RANK` (debug 10 … fatal 50). Status is **time-derived, never stored** (`getIncidentStatus(lastSeen)` vs `INCIDENT_AUTO_RESOLVE_MINUTES`); the client renders `data.autoResolveMinutes` from the server, so the two can't disagree.
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -127,7 +127,7 @@ These surfaced during the audit but were NOT turned into plans, with the reason.
 
 ### Minor items, not separately planned
 
-- **429 body-shape inconsistency**: `/v1/ingest` returns `{error, message}` while `/v1/logs` returns `{error}` for rate-limit responses. Cosmetic; plan 010 asserts both current shapes rather than normalizing. Fix opportunistically if touching both endpoints.
+- **429 body-shape inconsistency**: ~~`/v1/ingest` returns `{error, message}` while `/v1/logs` returns `{error}`~~ — fixed: the shared ingest pipeline (`utils/ingest.ts:ingestLogs`) normalizes both to `{error, message}` + `Retry-After: 60`; pipeline suite asserts both parsers.
 - **Timeline/timeseries final-bucket off-by-one** (BUG-03/BUG-04): the last time bucket can be computed slightly narrow. Minor visual effect on charts; not worth a dedicated migration-free change now. Revisit if charts show edge artifacts.
 - **Health-endpoint version disclosure**: the health endpoint exposes a version string. Low value to hide for a self-hosted tool; not worth the change.
 

--- a/src/lib/server/utils/log-query.ts
+++ b/src/lib/server/utils/log-query.ts
@@ -1,0 +1,135 @@
+import { and, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
+import type { DatabaseClient } from "$lib/server/db/db";
+import { log, type LogLevel } from "$lib/server/db/schema";
+import { cappedLogCount } from "$lib/server/utils/capped-count";
+import {
+  cursorRowLessThan,
+  decodeCursor,
+  encodeCursor,
+  microsColumn,
+} from "$lib/server/utils/cursor";
+import { buildSearchQuery } from "$lib/server/utils/search";
+
+export class InvalidCursorError extends Error {
+  constructor(message = "Invalid cursor") {
+    super(message);
+    this.name = "InvalidCursorError";
+  }
+}
+
+export interface LogQueryFilter {
+  projectId: string;
+  levels?: LogLevel[] | null;
+  from?: Date | null;
+  to?: Date | null;
+  search?: string | null;
+  cursor?: string | null;
+  limit: number;
+  offset?: number;
+}
+
+export interface QueriedLog {
+  id: string;
+  projectId: string;
+  incidentId: string | null;
+  fingerprint: string | null;
+  serviceName: string | null;
+  level: LogLevel;
+  message: string;
+  metadata: unknown;
+  sourceFile: string | null;
+  lineNumber: number | null;
+  requestId: string | null;
+  userId: string | null;
+  ipAddress: string | null;
+  timestamp: Date;
+}
+
+export interface LogQueryResult {
+  logs: QueriedLog[];
+  total: number | null;
+  totalIsCapped: boolean;
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export async function queryLogs(
+  db: DatabaseClient,
+  filter: LogQueryFilter,
+): Promise<LogQueryResult> {
+  const conditions: SQL[] = [eq(log.projectId, filter.projectId)];
+
+  if (filter.cursor) {
+    let cursorMicros: number;
+    let cursorId: string;
+    try {
+      ({ micros: cursorMicros, id: cursorId } = decodeCursor(filter.cursor));
+    } catch (error) {
+      throw new InvalidCursorError(error instanceof Error ? error.message : "Invalid cursor");
+    }
+    conditions.push(cursorRowLessThan(log.timestamp, log.id, cursorMicros, cursorId));
+  }
+
+  if (filter.levels && filter.levels.length > 0) {
+    conditions.push(inArray(log.level, filter.levels));
+  }
+
+  if (filter.from) {
+    conditions.push(gte(log.timestamp, filter.from));
+  }
+  if (filter.to) {
+    conditions.push(lte(log.timestamp, filter.to));
+  }
+
+  if (filter.search?.trim()) {
+    const tsquery = buildSearchQuery(filter.search);
+    if (tsquery) {
+      conditions.push(sql`${log.search} @@ to_tsquery('english', ${tsquery})`);
+    }
+  }
+
+  const whereClause = and(...conditions);
+
+  const countResult = filter.cursor ? undefined : await cappedLogCount(db, whereClause);
+
+  const rows = await db
+    .select({
+      id: log.id,
+      projectId: log.projectId,
+      incidentId: log.incidentId,
+      fingerprint: log.fingerprint,
+      serviceName: log.serviceName,
+      level: log.level,
+      message: log.message,
+      metadata: log.metadata,
+      sourceFile: log.sourceFile,
+      lineNumber: log.lineNumber,
+      requestId: log.requestId,
+      userId: log.userId,
+      ipAddress: log.ipAddress,
+      timestamp: log.timestamp,
+      micros: microsColumn(log.timestamp),
+    })
+    .from(log)
+    .where(whereClause)
+    .orderBy(desc(log.timestamp), desc(log.id))
+    .limit(filter.limit + 1)
+    .offset(filter.cursor ? 0 : (filter.offset ?? 0));
+
+  const hasMore = rows.length > filter.limit;
+  const page = hasMore ? rows.slice(0, filter.limit) : rows;
+  const last = page.at(-1);
+  const nextCursor = hasMore && last ? encodeCursor(Math.round(last.micros), last.id) : null;
+  const logsToReturn = page.map(
+    // oxlint-disable-next-line no-unused-vars
+    ({ micros, ...queried }) => queried,
+  );
+
+  return {
+    logs: logsToReturn,
+    total: countResult?.total ?? null,
+    totalIsCapped: countResult?.capped ?? false,
+    hasMore,
+    nextCursor,
+  };
+}

--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -1,12 +1,8 @@
-import { and, desc, eq, gte, inArray, lt, or, type SQL, sql } from "drizzle-orm";
-import { env } from "$lib/server/config/env";
 import { getDbClient } from "$lib/server/db/db";
-import { log } from "$lib/server/db/schema";
-import { cappedLogCount } from "$lib/server/utils/capped-count";
-import { decodeCursor, encodeCursor } from "$lib/server/utils/cursor";
+import { InvalidCursorError, queryLogs } from "$lib/server/utils/log-query";
 import { requireProjectOwnershipPage } from "$lib/server/utils/project-guard";
-import { buildSearchQuery } from "$lib/server/utils/search";
 import { parseLevelFilter } from "$lib/shared/schemas/log";
+import { env } from "$lib/server/config/env";
 import { getTimeRangeStart } from "$lib/utils/format";
 import { parseTimeRange } from "$lib/utils/time-range";
 import type { PageServerLoad } from "./$types";
@@ -43,75 +39,27 @@ export const load: PageServerLoad = async (event) => {
   const range = parseTimeRange(rangeParam);
   const fromDate = range ? getTimeRangeStart(range) : null;
 
-  const conditions: SQL[] = [eq(log.projectId, projectId)];
+  const filter = {
+    projectId,
+    levels,
+    from: fromDate,
+    to: null,
+    search: searchParam,
+    cursor: cursorParam,
+    limit,
+    offset,
+  };
 
-  if (cursorParam) {
-    try {
-      const { timestamp: cursorTimestamp, id: cursorId } = decodeCursor(cursorParam);
-
-      conditions.push(
-        or(
-          lt(log.timestamp, cursorTimestamp),
-          and(eq(log.timestamp, cursorTimestamp), lt(log.id, cursorId)),
-        ) as SQL,
-      );
-    } catch (err) {
-      console.error("[page/logs] invalid cursor, falling back to first page:", err);
-    }
+  let result: Awaited<ReturnType<typeof queryLogs>>;
+  try {
+    result = await queryLogs(db, filter);
+  } catch (err) {
+    if (!(err instanceof InvalidCursorError)) throw err;
+    console.error("[page/logs] invalid cursor, falling back to first page:", err);
+    result = await queryLogs(db, { ...filter, cursor: null });
   }
 
-  if (levels && levels.length > 0) {
-    conditions.push(inArray(log.level, levels));
-  }
-
-  if (fromDate) {
-    conditions.push(gte(log.timestamp, fromDate));
-  }
-
-  if (searchParam?.trim()) {
-    const tsquery = buildSearchQuery(searchParam);
-    if (tsquery) {
-      conditions.push(sql`${log.search} @@ to_tsquery('english', ${tsquery})`);
-    }
-  }
-
-  const whereClause = and(...conditions);
-
-  const pageCountResult = cursorParam ? undefined : await cappedLogCount(db, whereClause);
-  const total = pageCountResult?.total ?? 0;
-  const totalIsCapped = pageCountResult?.capped ?? false;
-
-  const logs = await db
-    .select({
-      id: log.id,
-      projectId: log.projectId,
-      incidentId: log.incidentId,
-      fingerprint: log.fingerprint,
-      serviceName: log.serviceName,
-      level: log.level,
-      message: log.message,
-      metadata: log.metadata,
-      sourceFile: log.sourceFile,
-      lineNumber: log.lineNumber,
-      requestId: log.requestId,
-      userId: log.userId,
-      ipAddress: log.ipAddress,
-      timestamp: log.timestamp,
-    })
-    .from(log)
-    .where(whereClause)
-    .orderBy(desc(log.timestamp), desc(log.id))
-    .limit(limit + 1)
-    .offset(cursorParam ? 0 : offset);
-
-  const hasMore = logs.length > limit;
-
-  const logsToReturn = hasMore ? logs.slice(0, limit) : logs;
-
-  const nextCursor =
-    hasMore && logsToReturn.length > 0
-      ? encodeCursor(logsToReturn.at(-1)!.timestamp as Date, logsToReturn.at(-1)!.id)
-      : null;
+  const total = result.total ?? 0;
 
   return {
     project: {
@@ -122,17 +70,17 @@ export const load: PageServerLoad = async (event) => {
       createdAt: projectData.createdAt?.toISOString() ?? null,
       updatedAt: projectData.updatedAt?.toISOString() ?? null,
     },
-    logs: logsToReturn.map((l) => ({
+    logs: result.logs.map((l) => ({
       ...l,
       timestamp: l.timestamp?.toISOString() ?? null,
     })),
     pagination: {
       total,
-      totalIsCapped,
-      hasMore,
+      totalIsCapped: result.totalIsCapped,
+      hasMore: result.hasMore,
       limit,
       offset,
-      nextCursor,
+      nextCursor: result.nextCursor,
     },
     filters: {
       levels: levels ?? [],

--- a/src/routes/api/projects/[id]/logs/+server.ts
+++ b/src/routes/api/projects/[id]/logs/+server.ts
@@ -1,17 +1,8 @@
 import { json } from "@sveltejs/kit";
-import { and, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { getDbClient } from "$lib/server/db/db";
-import { log } from "$lib/server/db/schema";
 import { apiError } from "$lib/server/utils/api-error";
-import { cappedLogCount } from "$lib/server/utils/capped-count";
-import {
-  decodeCursor,
-  encodeCursor,
-  cursorRowLessThan,
-  microsColumn,
-} from "$lib/server/utils/cursor";
+import { InvalidCursorError, queryLogs } from "$lib/server/utils/log-query";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
-import { buildSearchQuery } from "$lib/server/utils/search";
 import { parseLevelFilter } from "$lib/shared/schemas/log";
 import type { RequestEvent } from "./$types";
 
@@ -80,81 +71,27 @@ export async function GET(event: RequestEvent): Promise<Response> {
   const fromDate = fromParam ? new Date(fromParam) : null;
   const toDate = toParam ? new Date(toParam) : null;
 
-  const conditions: SQL[] = [eq(log.projectId, projectId)];
-
-  if (cursorParam) {
-    try {
-      const { micros: cursorMicros, id: cursorId } = decodeCursor(cursorParam);
-
-      conditions.push(cursorRowLessThan(log.timestamp, log.id, cursorMicros, cursorId));
-    } catch (error) {
-      return apiError(
-        400,
-        "invalid_cursor",
-        error instanceof Error ? error.message : "Invalid cursor",
-      );
+  let result: Awaited<ReturnType<typeof queryLogs>>;
+  try {
+    result = await queryLogs(db, {
+      projectId,
+      levels,
+      from: fromDate && !Number.isNaN(fromDate.getTime()) ? fromDate : null,
+      to: toDate && !Number.isNaN(toDate.getTime()) ? toDate : null,
+      search: searchParam,
+      cursor: cursorParam,
+      limit,
+      offset,
+    });
+  } catch (error) {
+    if (error instanceof InvalidCursorError) {
+      return apiError(400, "invalid_cursor", error.message);
     }
+    throw error;
   }
-
-  if (levels && levels.length > 0) {
-    conditions.push(inArray(log.level, levels));
-  }
-
-  if (fromDate && !Number.isNaN(fromDate.getTime())) {
-    conditions.push(gte(log.timestamp, fromDate));
-  }
-  if (toDate && !Number.isNaN(toDate.getTime())) {
-    conditions.push(lte(log.timestamp, toDate));
-  }
-
-  if (searchParam?.trim()) {
-    const tsquery = buildSearchQuery(searchParam);
-    if (tsquery) {
-      conditions.push(sql`${log.search} @@ to_tsquery('english', ${tsquery})`);
-    }
-  }
-
-  const whereClause = and(...conditions);
-
-  const countResult = cursorParam ? undefined : await cappedLogCount(db, whereClause);
-  const total = countResult?.total;
-  const totalIsCapped = countResult?.capped ?? false;
-
-  const logs = await db
-    .select({
-      id: log.id,
-      projectId: log.projectId,
-      incidentId: log.incidentId,
-      fingerprint: log.fingerprint,
-      serviceName: log.serviceName,
-      level: log.level,
-      message: log.message,
-      metadata: log.metadata,
-      sourceFile: log.sourceFile,
-      lineNumber: log.lineNumber,
-      requestId: log.requestId,
-      userId: log.userId,
-      ipAddress: log.ipAddress,
-      timestamp: log.timestamp,
-      micros: microsColumn(log.timestamp),
-    })
-    .from(log)
-    .where(whereClause)
-    .orderBy(desc(log.timestamp), desc(log.id))
-    .limit(limit + 1)
-    .offset(cursorParam ? 0 : offset);
-
-  const hasMore = logs.length > limit;
-
-  const logsToReturn = hasMore ? logs.slice(0, limit) : logs;
-
-  const nextCursor =
-    hasMore && logsToReturn.length > 0
-      ? encodeCursor(Math.round(logsToReturn.at(-1)!.micros), logsToReturn.at(-1)!.id)
-      : null;
 
   return json({
-    logs: logsToReturn.map((l) => ({
+    logs: result.logs.map((l) => ({
       id: l.id,
       projectId: l.projectId,
       incidentId: l.incidentId,
@@ -170,9 +107,9 @@ export async function GET(event: RequestEvent): Promise<Response> {
       ipAddress: l.ipAddress,
       timestamp: l.timestamp?.toISOString(),
     })),
-    total: total ?? null,
-    total_is_capped: totalIsCapped,
-    has_more: hasMore,
-    nextCursor,
+    total: result.total,
+    total_is_capped: result.totalIsCapped,
+    has_more: result.hasMore,
+    nextCursor: result.nextCursor,
   });
 }

--- a/src/routes/api/projects/[id]/logs/export/+server.ts
+++ b/src/routes/api/projects/[id]/logs/export/+server.ts
@@ -1,10 +1,10 @@
-import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
+import { and, count, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { EXPORT_CONFIG } from "$lib/server/config/performance";
 import { getDbClient } from "$lib/server/db/db";
 import { log } from "$lib/server/db/schema";
 import { apiError } from "$lib/server/utils/api-error";
-import { cursorRowLessThan, microsColumn } from "$lib/server/utils/cursor";
 import { escapeCSVField } from "$lib/server/utils/csv-serializer";
+import { queryLogs } from "$lib/server/utils/log-query";
 import { isErrorResponse, requireProjectOwnership } from "$lib/server/utils/project-guard";
 import { buildSearchQuery } from "$lib/server/utils/search";
 import { parseLevelFilter } from "$lib/shared/schemas/log";
@@ -134,40 +134,23 @@ export async function GET(event: RequestEvent): Promise<Response> {
         try {
           ctrl.enqueue(encoder.encode(`${CSV_HEADERS.join(",")}\n`));
 
-          let cursorMicros: number | null = null;
-          let cursorId: string | null = null;
+          let cursor: string | null = null;
           let fetched = 0;
 
           while (fetched < EXPORT_CONFIG.MAX_LOGS) {
-            const batchConditions: SQL[] = [...conditions];
-            if (cursorMicros !== null && cursorId !== null) {
-              batchConditions.push(
-                cursorRowLessThan(log.timestamp, log.id, cursorMicros, cursorId),
-              );
-            }
+            const page = await queryLogs(db, {
+              projectId,
+              levels,
+              from: fromDate && !Number.isNaN(fromDate.getTime()) ? fromDate : null,
+              to: toDate && !Number.isNaN(toDate.getTime()) ? toDate : null,
+              search: searchParam,
+              cursor,
+              limit: EXPORT_BATCH_SIZE,
+            });
 
-            const batch = await db
-              .select({
-                id: log.id,
-                level: log.level,
-                message: log.message,
-                metadata: log.metadata,
-                sourceFile: log.sourceFile,
-                lineNumber: log.lineNumber,
-                requestId: log.requestId,
-                userId: log.userId,
-                ipAddress: log.ipAddress,
-                timestamp: log.timestamp,
-                micros: microsColumn(log.timestamp),
-              })
-              .from(log)
-              .where(and(...batchConditions))
-              .orderBy(desc(log.timestamp), desc(log.id))
-              .limit(EXPORT_BATCH_SIZE);
+            if (page.logs.length === 0) break;
 
-            if (batch.length === 0) break;
-
-            for (const l of batch) {
+            for (const l of page.logs) {
               const values: unknown[] = [
                 l.id,
                 l.timestamp?.toISOString() ?? "",
@@ -183,12 +166,9 @@ export async function GET(event: RequestEvent): Promise<Response> {
               ctrl.enqueue(encoder.encode(`${values.map(escapeCSVField).join(",")}\n`));
             }
 
-            fetched += batch.length;
-            const last = batch.at(-1)!;
-            cursorMicros = Math.round(last.micros);
-            cursorId = last.id;
-
-            if (batch.length < EXPORT_BATCH_SIZE) break;
+            fetched += page.logs.length;
+            if (!page.hasMore || !page.nextCursor) break;
+            cursor = page.nextCursor;
           }
 
           ctrl.close();
@@ -212,39 +192,24 @@ export async function GET(event: RequestEvent): Promise<Response> {
       try {
         ctrl.enqueue(encoder.encode("["));
 
-        let cursorMicros: number | null = null;
-        let cursorId: string | null = null;
+        let cursor: string | null = null;
         let fetched = 0;
         let first = true;
 
         while (fetched < EXPORT_CONFIG.MAX_LOGS) {
-          const batchConditions: SQL[] = [...conditions];
-          if (cursorMicros !== null && cursorId !== null) {
-            batchConditions.push(cursorRowLessThan(log.timestamp, log.id, cursorMicros, cursorId));
-          }
+          const page = await queryLogs(db, {
+            projectId,
+            levels,
+            from: fromDate && !Number.isNaN(fromDate.getTime()) ? fromDate : null,
+            to: toDate && !Number.isNaN(toDate.getTime()) ? toDate : null,
+            search: searchParam,
+            cursor,
+            limit: EXPORT_BATCH_SIZE,
+          });
 
-          const batch = await db
-            .select({
-              id: log.id,
-              level: log.level,
-              message: log.message,
-              metadata: log.metadata,
-              sourceFile: log.sourceFile,
-              lineNumber: log.lineNumber,
-              requestId: log.requestId,
-              userId: log.userId,
-              ipAddress: log.ipAddress,
-              timestamp: log.timestamp,
-              micros: microsColumn(log.timestamp),
-            })
-            .from(log)
-            .where(and(...batchConditions))
-            .orderBy(desc(log.timestamp), desc(log.id))
-            .limit(EXPORT_BATCH_SIZE);
+          if (page.logs.length === 0) break;
 
-          if (batch.length === 0) break;
-
-          for (const l of batch) {
+          for (const l of page.logs) {
             const exportable = {
               id: l.id,
               level: l.level,
@@ -261,12 +226,9 @@ export async function GET(event: RequestEvent): Promise<Response> {
             first = false;
           }
 
-          fetched += batch.length;
-          const last = batch.at(-1)!;
-          cursorMicros = Math.round(last.micros);
-          cursorId = last.id;
-
-          if (batch.length < EXPORT_BATCH_SIZE) break;
+          fetched += page.logs.length;
+          if (!page.hasMore || !page.nextCursor) break;
+          cursor = page.nextCursor;
         }
 
         ctrl.enqueue(encoder.encode("]"));

--- a/tests/integration/log-query/log-query.integration.test.ts
+++ b/tests/integration/log-query/log-query.integration.test.ts
@@ -1,0 +1,126 @@
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type * as schema from "../../../src/lib/server/db/schema";
+import { setupTestDatabase } from "../../../src/lib/server/db/test-db";
+import { InvalidCursorError, queryLogs } from "../../../src/lib/server/utils/log-query";
+import { seedLog, seedProject } from "../../fixtures/db";
+
+describe("queryLogs module", () => {
+  let db: PgliteDatabase<typeof schema>;
+  let cleanup: () => Promise<void>;
+  let projectId: string;
+
+  beforeEach(async () => {
+    const setup = await setupTestDatabase();
+    db = setup.db;
+    cleanup = setup.cleanup;
+    projectId = (await seedProject(db)).id;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("filters by level and reports totals on the first page", async () => {
+    await seedLog(db, projectId, { level: "info", message: "all good" });
+    await seedLog(db, projectId, { level: "error", message: "it broke" });
+
+    const result = await queryLogs(db, { projectId, levels: ["error"], limit: 100 });
+
+    expect(result.logs).toHaveLength(1);
+    expect(result.logs[0]!.message).toBe("it broke");
+    expect(result.total).toBe(1);
+    expect(result.totalIsCapped).toBe(false);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("paginates by cursor without duplicates or gaps", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedLog(db, projectId, {
+        level: "info",
+        message: `log ${i}`,
+        timestamp: new Date(Date.now() + i * 1000),
+      });
+    }
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      const page = await queryLogs(db, { projectId, limit: 2, cursor });
+      if (cursor) expect(page.total).toBeNull();
+      else expect(page.total).toBe(5);
+      seen.push(...page.logs.map((entry) => entry.id));
+      cursor = page.nextCursor;
+      pages += 1;
+      if (!page.hasMore) break;
+    } while (cursor);
+
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(5);
+    expect(pages).toBe(3);
+  });
+
+  it("throws InvalidCursorError for malformed cursors", async () => {
+    await expect(queryLogs(db, { projectId, limit: 10, cursor: "not-a-cursor" })).rejects.toThrow(
+      InvalidCursorError,
+    );
+  });
+
+  it("narrows by full-text search", async () => {
+    await seedLog(db, projectId, { level: "info", message: "database connection pool ready" });
+    await seedLog(db, projectId, { level: "info", message: "unrelated startup message" });
+
+    const result = await queryLogs(db, { projectId, search: "database", limit: 100 });
+
+    expect(result.logs).toHaveLength(1);
+    expect(result.logs[0]!.message).toContain("database");
+  });
+
+  it("narrows by time range", async () => {
+    const base = Date.now();
+    await seedLog(db, projectId, {
+      level: "info",
+      message: "old",
+      timestamp: new Date(base - 3600_000),
+    });
+    await seedLog(db, projectId, { level: "info", message: "new", timestamp: new Date(base) });
+
+    const result = await queryLogs(db, {
+      projectId,
+      from: new Date(base - 60_000),
+      to: new Date(base + 60_000),
+      limit: 100,
+    });
+
+    expect(result.logs.map((entry) => entry.message)).toEqual(["new"]);
+  });
+
+  it("supports offset for back-compat callers", async () => {
+    for (let i = 0; i < 3; i++) {
+      await seedLog(db, projectId, {
+        level: "info",
+        message: `log ${i}`,
+        timestamp: new Date(Date.now() + i * 1000),
+      });
+    }
+
+    const first = await queryLogs(db, { projectId, limit: 10 });
+    const skipped = await queryLogs(db, { projectId, limit: 10, offset: 1 });
+
+    expect(first.logs).toHaveLength(3);
+    expect(skipped.logs).toHaveLength(2);
+    expect(skipped.logs[0]!.id).toBe(first.logs[1]!.id);
+  });
+
+  it("ignores cursor offset and isolates projects", async () => {
+    const otherId = (await seedProject(db, { name: `other-${nanoid(8)}` })).id;
+    await seedLog(db, projectId, { level: "info", message: "mine" });
+    await seedLog(db, otherId, { level: "info", message: "theirs" });
+
+    const result = await queryLogs(db, { projectId, limit: 100 });
+    expect(result.logs.map((entry) => entry.message)).toEqual(["mine"]);
+  });
+});


### PR DESCRIPTION
The logs route, export, and page loader each rebuilt the same
project + levels + range + search + cursor where-clause (the loader
even re-implemented cursor math). queryLogs() owns filter parsing,
where-building, and paged selection params-in/rows-out; invalid
cursors throw InvalidCursorError (route maps to 400, loader falls
back to first page, preserving both behaviors).

Tests: new module-level suite; route suites now exercise thin adapters.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>